### PR TITLE
fix(traffic light):  extract lane ID from instance_name

### DIFF
--- a/perception_eval/perception_eval/common/dataset_utils.py
+++ b/perception_eval/perception_eval/common/dataset_utils.py
@@ -28,6 +28,7 @@ from nuscenes.utils.data_classes import Box
 from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.common.label import LabelConverter
 from perception_eval.common.label import LabelType
+from perception_eval.common.label import TrafficLightLabel
 from perception_eval.common.object2d import DynamicObject2D
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.status import FrameID
@@ -414,7 +415,14 @@ def _sample_to_frame_2d(
             count_label_number=True,
         )
 
-        uuid: str = ann.get("instance_token")
+        if label_converter.label_type == TrafficLightLabel:
+            for instance_record in nusc.instance:
+                if instance_record["token"] == ann["instance_token"]:
+                    instance_name: str = instance_record["instance_name"]
+                    uuid: str = instance_name.split(":")[-1]
+        else:
+            uuid: str = ann["instance_token"]
+
         visibility = None
 
         object_: DynamicObject2D = DynamicObject2D(

--- a/perception_eval/test/perception_lsim2d.py
+++ b/perception_eval/test/perception_lsim2d.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
             "cam_back",
             "cam_back_left",
             "cam_back_right",
-            "cam_traffic_licht_near",
+            "cam_traffic_light_near",
             "cam_traffic_light_far",
         ],
         help="Name of camera data",

--- a/perception_eval/test/perception_lsim2d.py
+++ b/perception_eval/test/perception_lsim2d.py
@@ -157,6 +157,7 @@ if __name__ == "__main__":
         "--label_prefix",
         type=str,
         default="autoware",
+        choices=["autoware", "traffic_light"],
         help="Whether evaluate Traffic Light Recognition",
     )
     parser.add_argument(


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [x] Detection
  - [x] Tracking
  - [x] Classification

## What

<!-- Please describe what you changed. -->
Related to https://github.com/tier4/autoware_perception_evaluation/issues/53

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
