### PR TITLE
fix: calculation of fp results with high confidence

### DIFF
--- a/perception_eval/perception_eval/visualization/eda_tool.py
+++ b/perception_eval/perception_eval/visualization/eda_tool.py
@@ -525,7 +525,7 @@ class EDAManager:
             # visualize fp with high confidence in estimated objects
             confidence_threshold_list: List[float] = [confidence_threshold] * len(target_labels)
             fp_results_with_high_confidence = filter_object_results(
-                object_results=tp_results,
+                object_results=fp_results,
                 target_labels=target_labels,
                 confidence_threshold_list=confidence_threshold_list,
             )


### PR DESCRIPTION
## Category

- [x] Perception
  - [x] Detection

## What

In eda tool, false positives with high confidence are wrongly calculated. tp_results are passed to filtering function instead of fp_results.

## Type of change

- [x] Bug fix

## Test performed

<!-- Describe how you have tested this PR. -->

Visual comparison of histograms  before and after the fix (with tp_results and fp_results without a threshold)
