### PR TITLE
Filter classes in object count for distance

### DIFF
--- a/perception_eval/perception_eval/visualization/eda_tool.py
+++ b/perception_eval/perception_eval/visualization/eda_tool.py
@@ -185,9 +185,9 @@ class EDAVisualizer:
 
         fig: Figure = make_subplots(rows=1, cols=len(ranges_xy), subplot_titles=subplot_titles)
 
+        visualize_df = self.visualize_df[self.visualize_df.name.isin(class_names)]
         for i, range_xy in enumerate(ranges_xy):
-            _df: pd.DataFrame = self.visualize_df[self.visualize_df.distance_2d < range_xy]
-
+            _df: pd.DataFrame = visualize_df[visualize_df.distance_2d < range_xy]
             fig.add_trace(
                 go.Histogram(
                     x=_df["name"], name=f"#objects: ~{range_xy}m", marker=dict(color="blue")
@@ -196,8 +196,11 @@ class EDAVisualizer:
                 col=i + 1,
             )
 
-        fig.update_yaxes(range=[0, len(self.visualize_df)])
-        fig.update_xaxes(categoryorder="array", categoryarray=class_names)
+        fig.update_yaxes(range=[0, len(visualize_df)])
+        filtered_classes = visualize_df.name.unique().tolist()
+        fig.update_xaxes(
+            categoryorder="array", categoryarray=sorted(filtered_classes, key=class_names.index)
+        )
         if self.show:
             fig.show()
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x ] Perception
  - [ x] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->
Minor fix to show only bars of classes listed  in `class_names` (in object counts by distance plot).

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->
Generation of plots before and after change.

There are  cars, pedestrians and trucks in tested scene and plots are generated with `class_names = ["car", "pedestrian", "bicycle", "bus"]`

Plot generated without filtering:
- `truck` is also included despite not being listed in `class_names`
- `bicycle` and `bus` class is visible with no objects. This would be ok, but if  we put `bus` or `bicycle` as first or last in `class_names` list, then the bar is not visible. So due to inconsistent behaviour this is also changed and objects with `count>0` are not visible.
![image](https://github.com/tier4/autoware_perception_evaluation/assets/7488385/b25c55aa-5022-4252-8bb4-4e87ee55441b)

Plot generated with filtering:
![image](https://github.com/tier4/autoware_perception_evaluation/assets/7488385/061613df-934d-4470-b24c-fbb3547c3b75)

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
