### PR TITLE
feat(utils): add support of loading and saving pkl with version information

### DIFF
--- a/perception_eval/perception_eval/tool/perception_analyzer_base.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer_base.py
@@ -19,7 +19,6 @@ from abc import abstractmethod
 import logging
 import os
 import os.path as osp
-import pickle
 from typing import Any
 from typing import Dict
 from typing import List
@@ -43,6 +42,7 @@ from perception_eval.evaluation import PerceptionFrameResult
 from perception_eval.evaluation.matching.objects_filter import divide_objects
 from perception_eval.evaluation.matching.objects_filter import divide_objects_to_num
 from perception_eval.evaluation.metrics.metrics import MetricsScore
+from perception_eval.util.file import load_pkl
 from tqdm import tqdm
 
 from .utils import filter_df
@@ -521,8 +521,7 @@ class PerceptionAnalyzerBase(ABC):
         Returns:
             pandas.DataFrame
         """
-        with open(pickle_path, "rb") as pickle_file:
-            frame_results: List[PerceptionFrameResult] = pickle.load(pickle_file)
+        frame_results: List[PerceptionFrameResult] = load_pkl(pickle_path)
         return self.add(frame_results)
 
     def clear(self) -> None:

--- a/perception_eval/perception_eval/tool/perception_analyzer_base.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer_base.py
@@ -42,7 +42,7 @@ from perception_eval.evaluation import PerceptionFrameResult
 from perception_eval.evaluation.matching.objects_filter import divide_objects
 from perception_eval.evaluation.matching.objects_filter import divide_objects_to_num
 from perception_eval.evaluation.metrics.metrics import MetricsScore
-from perception_eval.util.file import load_pkl
+from perception_eval.util import load_pkl
 from tqdm import tqdm
 
 from .utils import filter_df

--- a/perception_eval/perception_eval/util/__init__.py
+++ b/perception_eval/perception_eval/util/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .file import dump_to_pkl
+from .file import load_pkl
+
+__all__ = ("dump_to_pkl", "load_pkl")

--- a/perception_eval/perception_eval/util/file.py
+++ b/perception_eval/perception_eval/util/file.py
@@ -16,6 +16,7 @@ from io import BufferedWriter
 import os
 import pickle
 from typing import Any
+from typing import List
 from typing import Tuple
 from typing import Union
 import warnings
@@ -75,10 +76,12 @@ def load_pkl(filepath: str) -> Any:
             )
             return data
         else:
-            version: str = data["version"]
-            if __version__.split(".")[1] != version.split(".")[1]:
+            current_versions: List[str] = __version__.split(".")
+            saved_version_info: str = data["version"]
+            saved_versions: List[str] = saved_version_info.split(".")
+            if current_versions[0] != saved_versions[0] or current_versions[1] != saved_versions[1]:
                 raise ValueError(
-                    f"Minor version mismatch: using perception_eval: {__version__}, pkl: {version}"
+                    f"Minor version mismatch: using perception_eval: {__version__}, pkl: {saved_version_info}"
                 )
             return data["data"]
 

--- a/perception_eval/perception_eval/util/file.py
+++ b/perception_eval/perception_eval/util/file.py
@@ -68,11 +68,26 @@ def load_pkl(filepath: str) -> Any:
         Any: Any python objects stored in "data".
     """
     with open(filepath, "rb") as pickle_file:
-        data: Any = pickle.load(pickle_file)
-        if not isinstance(data, dict) or data.get("version") is None or data.get("data") is None:
+        try:
+            data: Any = pickle.load(pickle_file)
+        except Exception as e:
+            print(e)
+            raise ValueError(
+                "[NOTICE]: Version of `perception_eval` in pickle is too old, "
+                f"current version is {__version__}."
+            )
+
+        if not isinstance(data, dict):
             warnings.warn(
                 "Expected serialized pkl format is `dict['version': str, 'data': Any]`, "
-                f"which contains `version` information, but got type: {type(data)}, version: {data.get('version')}.",
+                f"which contains `version` information, but got type: {type(data)}",
+                DeprecationWarning,
+            )
+            return data
+        elif isinstance(data, dict) and data.get("version") is None or data.get("data") is None:
+            warnings.warn(
+                "Expected serialized pkl format is `dict['version': str, 'data': Any]`, "
+                f"which contains `version` information, but got keys: {list(data.keys())}",
                 DeprecationWarning,
             )
             return data

--- a/perception_eval/perception_eval/util/file.py
+++ b/perception_eval/perception_eval/util/file.py
@@ -54,10 +54,10 @@ def load_pkl(filepath: str) -> Any:
 
     NOTE:
         Expecting serialized pickle data type is `dict`, which contains `version` information.
-        ```shell
-        data (dict)
-            - version (str)
-            - ... any data
+        ```python
+        deserialized_data (dict)
+            - "version" (str)
+            - "data" (Any)
         ```
         Returns data excluding version information.
 
@@ -65,14 +65,15 @@ def load_pkl(filepath: str) -> Any:
         filepath (str): Pickle file path.
 
     Returns:
-        Any:
+        Any: Any python objects stored in "data".
     """
     with open(filepath, "rb") as pickle_file:
         data: Any = pickle.load(pickle_file)
         if not isinstance(data, dict) or data.get("version") is None or data.get("data") is None:
             warnings.warn(
-                "[DEPRECATED FORMAT]: Expected serialized pkl format is `dict['version': str, 'data': Any]`, "
-                f"which contains `version` information, but got type: {type(data)}, version: {data.get('version')}."
+                "Expected serialized pkl format is `dict['version': str, 'data': Any]`, "
+                f"which contains `version` information, but got type: {type(data)}, version: {data.get('version')}.",
+                DeprecationWarning,
             )
             return data
         else:
@@ -81,7 +82,7 @@ def load_pkl(filepath: str) -> Any:
             saved_versions: List[str] = saved_version_info.split(".")
             if current_versions[0] != saved_versions[0] or current_versions[1] != saved_versions[1]:
                 raise ValueError(
-                    f"Minor version mismatch: using perception_eval: {__version__}, pkl: {saved_version_info}"
+                    f"Version mismatch: using perception_eval: {__version__}, pkl: {saved_version_info}"
                 )
             return data["data"]
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Other

## What

<!-- Please describe what you changed. -->

Add `load_pkl()` and `dump_to_pkl()` function to save and load pkl with version information of using `perception_eval`.

- If users want to load old pkl file, load_pkl() warns deprecated format.
- If users load pkl file that has invalid major or minor version compared to version of using `perception_eval`, load_pkl() raises ValueError.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
