### PR TITLE
fix: remove to specify kwargs in `summarize_score`

### DIFF
--- a/perception_eval/perception_eval/tool/perception_analyzer2d.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer2d.py
@@ -240,7 +240,7 @@ class PerceptionAnalyzer2D(PerceptionAnalyzerBase):
         if len(df) > 0:
             ratio_df = self.summarize_ratio(df=df)
             confusion_matrix_df = self.get_confusion_matrix(df=df)
-            metrics_df = self.summarize_score(scene=kwargs.get("scene"), **kwargs)
+            metrics_df = self.summarize_score(scene=kwargs.get("scene"))
             score_df = pd.concat([ratio_df, metrics_df], axis=1)
             return score_df, confusion_matrix_df
 

--- a/perception_eval/perception_eval/tool/perception_analyzer_base.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer_base.py
@@ -463,7 +463,11 @@ class PerceptionAnalyzerBase(ABC):
         if len(df) > 0:
             ratio_df = self.summarize_ratio(df=df)
             error_df = self.summarize_error(df=df)
-            metrics_df = self.summarize_score(scene=kwargs.get("scene"), **kwargs)
+            if "scene" in kwargs.keys():
+                scene = kwargs.pop("scene")
+            else:
+                scene = None
+            metrics_df = self.summarize_score(scene=scene, **kwargs)
             score_df = pd.concat([ratio_df, metrics_df], axis=1)
             return score_df, error_df
 
@@ -697,7 +701,7 @@ class PerceptionAnalyzerBase(ABC):
                 data["FN"][i] = self.get_num_fn(label=label) / num_ground_truth
         return pd.DataFrame(data, index=self.all_labels)
 
-    def summarize_score(self, scene: Optional[Union[int, List[int]]] = None) -> pd.DataFrame:
+    def summarize_score(self, scene: Optional[Union[int, List[int]]] = None, *args, **kwargs) -> pd.DataFrame:
         """Summarize MetricsScore.
 
         Args:


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

Fix to handle kwargs for `summarize_score` in analyzers.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
