### PR TITLE
fix: resolve invalid attribute access for `HomogeneousMatrix`

### DIFF
--- a/perception_eval/perception_eval/common/dataset.py
+++ b/perception_eval/perception_eval/common/dataset.py
@@ -361,7 +361,11 @@ def interpolate_ground_truth_frames(
     before_frame_ego2map = before_frame.transforms[ego2map_key]
     after_frame_ego2map = after_frame.transforms[ego2map_key]
     ego2map_matrix = interpolate_homogeneous_matrix(
-        before_frame_ego2map, after_frame_ego2map, before_frame.unix_time, after_frame.unix_time, unix_time
+        before_frame_ego2map.matrix,
+        after_frame_ego2map.matrix,
+        before_frame.unix_time,
+        after_frame.unix_time,
+        unix_time,
     )
     ego2map = HomogeneousMatrix.from_matrix(ego2map_matrix, src=FrameID.BASE_LINK, dst=FrameID.MAP)
 

--- a/perception_eval/perception_eval/common/geometry.py
+++ b/perception_eval/perception_eval/common/geometry.py
@@ -14,16 +14,12 @@
 
 from copy import deepcopy
 from typing import List
-from typing import Tuple
 from typing import Union
 
 import numpy as np
 from perception_eval.common.object2d import DynamicObject2D
-from perception_eval.common.object2d import Roi
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.object import ObjectState
-from perception_eval.common.point import distance_points
-from perception_eval.common.point import distance_points_bev
 from pyquaternion import Quaternion
 
 # Type aliases

--- a/perception_eval/perception_eval/common/transform.py
+++ b/perception_eval/perception_eval/common/transform.py
@@ -244,6 +244,10 @@ class HomogeneousMatrix:
         return cls(position, rotation, src, dst)
 
     @property
+    def shape(self):
+        return self.matrix.shape
+
+    @property
     def yaw_pitch_roll(self) -> Tuple[float, float, float]:
         """Get the equivalent (yaw, pitch, roll) angles in radius.
 

--- a/perception_eval/test/perception_lsim.py
+++ b/perception_eval/test/perception_lsim.py
@@ -17,6 +17,7 @@ import logging
 import tempfile
 from typing import List
 
+from perception_eval.common.evaluation_task import EvaluationTask
 from perception_eval.common.object import DynamicObject
 from perception_eval.config import PerceptionEvaluationConfig
 from perception_eval.evaluation import PerceptionFrameResult
@@ -95,7 +96,10 @@ class PerceptionLSimMoc:
         estimated_objects: List[DynamicObject],
     ) -> None:
         # 現frameに対応するGround truthを取得
-        ground_truth_now_frame = self.evaluator.get_ground_truth_now_frame(unix_time)
+        interpolate = not self.evaluator.evaluation_task == EvaluationTask.DETECTION
+        ground_truth_now_frame = self.evaluator.get_ground_truth_now_frame(
+            unix_time, interpolate_ground_truth=interpolate
+        )
 
         # [Option] ROS側でやる（Map情報・Planning結果を用いる）UC評価objectを選別
         # ros_critical_ground_truth_objects : List[DynamicObject] = custom_critical_object_filter(


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

```shell
get_interpolated_now_frame
[perception_evaluator_node.py-65]     return interpolate_ground_truth_frames(before_frame, after_frame, unix_time)
[perception_evaluator_node.py-65]   File "/home/autoware/pilot-auto/install/perception_eval/local/lib/python3.10/dist-packages/perception_eval/common/dataset.py", line 363, in interpolate_ground_truth_frames
[perception_evaluator_node.py-65]     ego2map_matrix = interpolate_homogeneous_matrix(
[perception_evaluator_node.py-65]   File "/home/autoware/pilot-auto/install/perception_eval/local/lib/python3.10/dist-packages/perception_eval/common/geometry.py", line 44, in interpolate_homogeneous_matrix
[perception_evaluator_node.py-65]     assert matrix_1.shape == matrix_2.shape
[perception_evaluator_node.py-65] AttributeError: 'HomogeneousMatrix' object has no attribute 'shape'
```

This PR should be merged after [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/31843179-b9ca-5943-a19b-73f43c425b94?project_id=prd_jt) is passed.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
