### PR TITLE
fix: use mean threshold value for unknwon labeled estimations if unkn…

### DIFF
--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -19,11 +19,11 @@ from typing import Tuple
 from typing import Union
 import warnings
 
+import numpy as np
 from perception_eval.common import ObjectType
 from perception_eval.common.label import CommonLabel
 from perception_eval.common.label import Label
 from perception_eval.common.label import LabelType
-from perception_eval.common.object2d import DynamicObject2D
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.schema import FrameID
 from perception_eval.common.status import MatchingStatus
@@ -517,6 +517,7 @@ def _is_target_object(
         any([label == CommonLabel.UNKNOWN for label in target_labels]) if target_labels is not None else False
     )
 
+    # use special threshold for unknown labeled estimations
     use_unknown_threshold: bool = is_unknown_estimation and not is_contained_unknown
 
     label_threshold = LabelThreshold(
@@ -557,7 +558,7 @@ def _is_target_object(
     if position_ is not None:
         if is_target and max_x_position_list is not None:
             max_x_position = (
-                max_x_position_list[0]
+                np.mean(max_x_position_list)
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_x_position_list)
             )
@@ -565,7 +566,7 @@ def _is_target_object(
 
         if is_target and max_y_position_list is not None:
             max_y_position = (
-                max_y_position_list[0]
+                np.mean(max_y_position_list)
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_y_position_list)
             )
@@ -574,7 +575,7 @@ def _is_target_object(
     if bev_distance_ is not None:
         if is_target and max_distance_list is not None:
             max_distance = (
-                max_distance_list[0]
+                np.mean(max_distance_list)
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_distance_list)
             )
@@ -582,7 +583,7 @@ def _is_target_object(
 
         if is_target and min_distance_list is not None:
             min_distance = (
-                min_distance_list[0]
+                np.mean(min_distance_list)
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(min_distance_list)
             )


### PR DESCRIPTION
…own is not contained in `target_labels`

## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

Update to use mean threshold value for unknown estimations if unknown is not specified in `target_labels`.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
