### PR TITLE
refactor: not to compare types by `type(...) == type(...)`

### DIFF
--- a/perception_eval/perception_eval/common/geometry.py
+++ b/perception_eval/perception_eval/common/geometry.py
@@ -150,7 +150,7 @@ def interpolate_object(object_1: ObjectType, object_2: ObjectType, t1: float, t2
          object_2 (ObjectType): An object
     Returns: ObjectType: The interpolated object.
     """
-    if type(object_1) != type(object_2):
+    if not isinstance(object_1, type(object_2)):
         raise TypeError(f"objects' type must be same, but got {type(object_1) and {type(object_2)}}")
 
     if isinstance(object_1, DynamicObject):

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -73,7 +73,7 @@ class MatchingMethod(ABC):
         ground_truth_object: Optional[ObjectType],
     ) -> None:
         if ground_truth_object is not None:
-            assert type(estimated_object) == type(ground_truth_object)
+            assert isinstance(estimated_object, type(ground_truth_object))
         self.value: Optional[float] = self._calculate_matching_score(
             estimated_object=estimated_object,
             ground_truth_object=ground_truth_object,


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

In accordance with [Flake8(E721)](https://www.flake8rules.com/rules/E721.html), this PR revises to compare type of two objects by `isinstance(obj1, type(obj2))` instead of `type(obj1) == type(obj2)`

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] Refactoring

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
