### PR TITLE
fix(perception): resolve analyzer errors

### DIFF
--- a/perception_eval/perception_eval/tool/perception_analyzer_base.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer_base.py
@@ -822,7 +822,7 @@ class PerceptionAnalyzerBase(ABC):
         gt_df, est_df = self.get_pair_results(df)
 
         target_labels: List[str] = self.target_labels.copy()
-        if self.config.label_params["allow_matching_unknown"] and "unknown" not in target_labels:
+        if "unknown" not in target_labels:
             target_labels.append("unknown")
 
         gt_indices: np.ndarray = gt_df["label"].apply(lambda label: target_labels.index(label)).to_numpy()

--- a/perception_eval/perception_eval/tool/perception_analyzer_base.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer_base.py
@@ -783,8 +783,9 @@ class PerceptionAnalyzerBase(ABC):
             if num_ground_truth > 0:
                 num_tp = self.get_num_tp(df=df, label=label)
                 num_fp = self.get_num_fp(df=df, label=label)
+                num_det = num_tp + num_fp  # If all FN, num_det = 0
                 data["TP"][i] = num_tp / num_ground_truth
-                data["FP"][i] = num_fp / (num_tp + num_fp)  # False Discovery Rate
+                data["FP"][i] = num_fp / num_det if num_det != 0 else 0.0  # False Discovery Rate
                 data["TN"][i] = self.get_num_tn(df=df, label=label) / num_ground_truth
                 data["FN"][i] = self.get_num_fn(df=df, label=label) / num_ground_truth
         return pd.DataFrame(data, index=self.all_labels)


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

- Avoid `ZeroDivisionError` while computing False Discovery Rate.
- Append "unknown" if it is not contained in `target_labels` but some estimations do.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] Bug fix

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
