### PR TITLE
fix: initialize attributes when that does not exist

### DIFF
--- a/perception_eval/perception_eval/tool/perception_analyzer2d.py
+++ b/perception_eval/perception_eval/tool/perception_analyzer2d.py
@@ -173,8 +173,8 @@ class PerceptionAnalyzer2D(PerceptionAnalyzerBase):
                 gt_x_offset, gt_y_offset = gt.roi.offset
                 gt_width, gt_height = gt.roi.size
             else:
-                gt_x_offset, gt_y_offset = None, None
-                gt_width, gt_height = None, None
+                gt_x_offset, gt_y_offset = np.nan, np.nan
+                gt_width, gt_height = np.nan, np.nan
 
             gt_ret = dict(
                 frame_id=gt.frame_id.value,
@@ -193,15 +193,20 @@ class PerceptionAnalyzer2D(PerceptionAnalyzerBase):
                 scene=self.num_scene,
             )
         else:
-            gt_ret = {k: None for k in self.keys()}
+            gt_ret = {}
+            for key in self.keys():
+                if key in ("gt_x_offset", "gt_y_offset", "gt_width", "gt_height"):
+                    gt_ret[key] = np.nan
+                else:
+                    gt_ret[key] = None
 
         if estimation:
             if estimation.roi is not None:
                 est_x_offset, est_y_offset = estimation.roi.offset
                 est_width, est_height = estimation.roi.size
             else:
-                est_x_offset, est_y_offset = None, None
-                est_width, est_height = None, None
+                est_x_offset, est_y_offset = np.nan, np.nan
+                est_width, est_height = np.nan, np.nan
 
             est_ret = dict(
                 frame_id=estimation.frame_id,
@@ -221,7 +226,12 @@ class PerceptionAnalyzer2D(PerceptionAnalyzerBase):
                 scene=self.num_scene,
             )
         else:
-            est_ret = {k: None for k in self.keys()}
+            est_ret = {}
+            for key in self.keys():
+                if key in ("est_x_offset", "est_y_offset", "est_width", "est_height"):
+                    est_ret[key] = np.nan
+                else:
+                    est_ret[key] = None
 
         return {"ground_truth": gt_ret, "estimation": est_ret}
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [x] Classification
- [ ] Sensing
- [ ] Other

## What
change attributes(e.g. self.df["x"]) initialize value in `PerceptionAnalyzer2D` from `None` to `np.nan`.
For now, this repository has error when use traffic light evaluation.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed
I also checked this PR using DLR.

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [x] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference
This PR is similar to the error within https://github.com/tier4/autoware_perception_evaluation/pull/124
<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
