### PR TITLE
fix: max and min distance filter initialization

### DIFF
--- a/perception_eval/perception_eval/config/perception_evaluation_config.py
+++ b/perception_eval/perception_eval/config/perception_evaluation_config.py
@@ -141,12 +141,12 @@ class PerceptionEvaluationConfig(_EvaluationConfigBase):
         min_distance: Optional[float] = e_cfg.get("min_distance")
 
         num_elements: int = len(target_labels)
-        if max_x_position and max_y_position:
+        if None not in (max_x_position, max_y_position):
             max_x_position_list: List[float] = set_thresholds(max_x_position, num_elements, False)
             max_y_position_list: List[float] = set_thresholds(max_y_position, num_elements, False)
             max_distance_list = None
             min_distance_list = None
-        elif max_distance and min_distance:
+        elif None not in (max_distance, min_distance):
             max_distance_list: List[float] = set_thresholds(max_distance, num_elements, False)
             min_distance_list: List[float] = [min_distance] * len(target_labels)
             max_x_position_list = None


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [ ] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [x] Other

## What
Fix max and min distance filter in `PerceptionEvaluationConfig`.
In Before code, if the variable(e.g. `min_distance`) is set to 0, expected condition is not met. Therefore, I fix to check if the variable is `None` or not.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
