### PR TITLE
feat(perception): update the order of filtering out objects

### DIFF
--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -94,19 +94,24 @@ def filter_object_results(
     """
     filtered_object_results: List[DynamicObjectWithPerceptionResult] = []
     for object_result in object_results:
-        is_target: bool = _is_target_object(
-            dynamic_object=object_result.estimated_object,
-            is_gt=False,
-            target_labels=target_labels,
-            max_x_position_list=max_x_position_list,
-            max_y_position_list=max_y_position_list,
-            max_distance_list=max_distance_list,
-            min_distance_list=min_distance_list,
-            confidence_threshold_list=confidence_threshold_list,
-            transforms=transforms,
-        )
-        if is_target and object_result.ground_truth_object:
-            is_target = is_target and _is_target_object(
+        if object_result.ground_truth_object is None:
+            is_target: bool = (
+                _is_target_object(
+                    dynamic_object=object_result.estimated_object,
+                    is_gt=False,
+                    target_labels=target_labels,
+                    max_x_position_list=max_x_position_list,
+                    max_y_position_list=max_y_position_list,
+                    max_distance_list=max_distance_list,
+                    min_distance_list=min_distance_list,
+                    confidence_threshold_list=confidence_threshold_list,
+                    transforms=transforms,
+                )
+                if not target_uuids  # NOTE: target uuids are only valid for GT objects
+                else False
+            )
+        else:
+            is_target = _is_target_object(
                 dynamic_object=object_result.ground_truth_object,
                 is_gt=True,
                 target_labels=target_labels,
@@ -119,8 +124,6 @@ def filter_object_results(
                 target_uuids=target_uuids,
                 transforms=transforms,
             )
-        elif target_uuids and object_result.ground_truth_object is None:
-            is_target = False
 
         if is_target:
             filtered_object_results.append(object_result)

--- a/perception_eval/perception_eval/manager/perception_evaluation_manager.py
+++ b/perception_eval/perception_eval/manager/perception_evaluation_manager.py
@@ -173,13 +173,6 @@ class PerceptionEvaluationManager(_EvaluationMangerBase):
             **self.filtering_params,
         )
 
-        if self.evaluator_config.filtering_params.get("target_uuids"):
-            object_results = filter_object_results(
-                object_results=object_results,
-                transforms=frame_ground_truth.transforms,
-                target_uuids=self.filtering_params["target_uuids"],
-            )
-
         return object_results, frame_ground_truth
 
     def get_scene_result(self) -> MetricsScore:


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->

Currently, the manager filters out both estimations and GTs first. Then it generates object results.
It causes filtering out estimated objects before matching if their label are out of evaluation, then corresponding GT is evaluated as FN. However we should evaluate these case as FP.

![FilteringOrder](https://github.com/user-attachments/assets/f32f23be-028a-48ce-9f0b-3f572d2ac798)
 
This PR updates the order of filtering out objects in `PerceptionEvaluationManager` as follows:

### Before

1. Filtering out estimated and GT objects by filtering parameters.
2. Generating object results.

### After

1. Filtering out only GT objects by filtering parameters.
2. Generating object results.
3. Filtering out FP results whose status are out of evaluation.

This change allows to pair estimation, whose label is out of evaluation and GT whose label is 

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
