### PR TITLE
fix: skip loading radar pointcloud

### DIFF
--- a/perception_eval/perception_eval/common/dataset_utils.py
+++ b/perception_eval/perception_eval/common/dataset_utils.py
@@ -310,6 +310,9 @@ def _load_raw_data(nusc: NuScenes, sample_token: str) -> Dict[FrameID, NDArray]:
         filepath: str = nusc.get_sample_data_path(sample_data_token)
         if osp.basename(filepath).endswith("bin"):
             raw_data = np.fromfile(filepath, dtype=np.float32).reshape(-1, 5)[:, :4]
+        elif osp.basename(filepath).endswith("pcd"):
+            # skip loading radar pointcloud
+            continue
         else:
             raw_data = np.array(Image.open(filepath), dtype=np.uint8)
         output[frame_id] = raw_data


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception

## What

<!-- Please describe what you changed. -->

This PR includes skipping loading radar pointcloud file during loading dataset.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
