### PR TITLE
feat(perception): enable to filter based on `region`

### DIFF
--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -53,8 +53,9 @@ def filter_object_results(
 ) -> List[DynamicObjectWithPerceptionResult]:
     """Filter DynamicObjectWithPerceptionResult considering both estimated and ground truth objects.
 
-    If any of `target_labels`, `max_x_position_list`, `max_y_position_list`, `max_distance_list`, `min_distance_list`,
-    `min_point_numbers` or `confidence_threshold_list` are specified, each of them must be same length list.
+    If any of `target_labels`, `max_x_position_list`, `min_x_position_list`, `max_y_position_list`, `min_y_position_list`,
+    `max_distance_list`, `min_distance_list`, `min_point_numbers` or `confidence_threshold_list`
+    are specified, each of them must be same length list.
 
     It first filters `object_results` with input parameters considering estimated objects.
     After that, remained `object_results` are filtered with input parameters considering ground truth objects.
@@ -66,16 +67,18 @@ def filter_object_results(
             have same label in this list. Defaults to None.
         ignore_attributes (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
+            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
+            If `min_x_position_list` is not specified, keep them that each x position are in [`-max_x_position`, `max_x_position`].
         min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
+            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
+            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
+            If `min_y_position_list` is not specified, keep them that each y position are in [`-max_y_position`, `max_y_position`].
         min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
+            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `object_results` that their each distance is smaller than `max_distance`
@@ -160,8 +163,9 @@ def filter_objects(
 ) -> List[ObjectType]:
     """Filter DynamicObject considering ground truth objects.
 
-    If any of `target_labels`, `max_x_position_list`, `max_y_position_list`, `max_distance_list`, `min_distance_list`,
-    `min_point_numbers` or `confidence_threshold_list` are specified, each of them must be same length list.
+    If any of `target_labels`, `max_x_position_list`, `min_x_position_list`, `max_y_position_list`, `min_y_position_list`,
+    `max_distance_list`, `min_distance_list`, `min_point_numbers` or `confidence_threshold_list`
+    are specified, each of them must be same length list.
 
     Args:
         objects (List[ObjectType]: The objects you want to filter.
@@ -170,15 +174,19 @@ def filter_objects(
             Keep all `objects` that have same label in this list. Defaults to None.
         attributes_ignore (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
+            Keep all `objects` that their each x position are in [`-max_x_position`, `max_x_position`].
+            If `min_x_position_list` is not specified, keep them that each x position are smaller than `max_x_position`.
             Defaults to None.
         min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
+            Keep all `objects` that their each x position are bigger than `min_x_position`.
+            Defaults to None.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
+            Keep all `objects` that their each y posiition are in [`-max_y_position`, `max_y_position`].
+            If `min_y_position_list` is not specified, keep them that each y position are smaller than `max_y_position`.
             Defaults to None.
         min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
+            Keep all `objects` that their each y position are bigger than `min_y_position`.
+            Defaults to None.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `objects` that their each distance is smaller than `max_distance`. Defaults to None.
         min_distance_list (Optional[List[float]]): Thresholds list of minimum distance range from ego vehicle.
@@ -505,15 +513,17 @@ def _is_target_object(
             Keep all `dynamic_object` that have same labels in this list. Defaults to None.
         ignore_attributes (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
+            Keep all `dynamic_object` that their each x position are in [`-max_x_position`, `max_x_position`].
+            If `min_x_position_list` is not specified, keep them that each x position are smaller than `max_x_position`.
             Defaults to None.
         min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
+            Keep all `dynamic_object` that their each x position are bigger than `min_x_position`.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
+            Keep all `dynamic_object` that their each y position are in [`-max_y_position`, `max_y_position`].
+            If `min_y_position_list` is not specified, keep them that each y position are smaller than `max_y_position`.
             Defaults to None.
         min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
+            Keep all `dynamic_object` that their each y position are bigger than `min_y_position`.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `dynamic_object` that their each distance is smaller than `max_distance`. Defaults to None.
         min_distance_list (Optional[List[float]]): Thresholds list of minimum distance range from ego vehicle.
@@ -615,6 +625,22 @@ def _is_target_object(
                 is_target = is_target and position_[1] > min_y_position
             else:
                 is_target = is_target and abs(position_[1]) < max_y_position
+
+        if is_target and min_x_position_list is not None:
+            min_x_position = (
+                np.mean(min_x_position_list)
+                if use_unknown_threshold
+                else label_threshold.get_label_threshold(min_x_position_list)
+            )
+            is_target = is_target and position_[0] > min_x_position
+
+        if is_target and min_y_position_list is not None:
+            min_y_position = (
+                np.mean(min_y_position_list)
+                if use_unknown_threshold
+                else label_threshold.get_label_threshold(min_y_position_list)
+            )
+            is_target = is_target and position_[1] > min_y_position
 
     if bev_distance_ is not None:
         if is_target and max_distance_list is not None:

--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -588,15 +588,16 @@ def _is_target_object(
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_x_position_list)
             )
-            is_target = is_target and position_[0] < max_x_position
-
-        if is_target and min_x_position_list is not None:
-            min_x_position = (
-                np.mean(min_x_position_list)
-                if use_unknown_threshold
-                else label_threshold.get_label_threshold(min_x_position_list)
-            )
-            is_target = is_target and position_[0] > min_x_position
+            if min_x_position_list is not None:
+                is_target = is_target and position_[0] < max_x_position
+                min_x_position = (
+                    np.mean(min_x_position_list)
+                    if use_unknown_threshold
+                    else label_threshold.get_label_threshold(min_x_position_list)
+                )
+                is_target = is_target and position_[0] > min_x_position
+            else:
+                is_target = is_target and abs(position_[0]) < max_x_position
 
         if is_target and max_y_position_list is not None:
             max_y_position = (
@@ -604,15 +605,16 @@ def _is_target_object(
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_y_position_list)
             )
-            is_target = is_target and position_[1] < max_y_position
-        
-        if is_target and min_y_position_list is not None:
-            min_y_position = (
-                np.mean(min_y_position_list)
-                if use_unknown_threshold
-                else label_threshold.get_label_threshold(min_y_position_list)
-            )
-            is_target = is_target and position_[1] > min_y_position
+            if min_y_position_list is not None:
+                is_target = is_target and position_[1] < max_y_position
+                min_y_position = (
+                    np.mean(min_y_position_list)
+                    if use_unknown_threshold
+                    else label_threshold.get_label_threshold(min_y_position_list)
+                )
+                is_target = is_target and position_[1] > min_y_position
+            else:
+                is_target = is_target and abs(position_[1]) < max_y_position
 
     if bev_distance_ is not None:
         if is_target and max_distance_list is not None:

--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -39,7 +39,9 @@ def filter_object_results(
     target_labels: Optional[List[LabelType]] = None,
     ignore_attributes: Optional[List[str]] = None,
     max_x_position_list: Optional[List[float]] = None,
+    min_x_position_list: Optional[List[float]] = None,
     max_y_position_list: Optional[List[float]] = None,
+    min_y_position_list: Optional[List[float]] = None,
     max_distance_list: Optional[List[float]] = None,
     min_distance_list: Optional[List[float]] = None,
     min_point_numbers: Optional[List[int]] = None,
@@ -64,10 +66,16 @@ def filter_object_results(
             have same label in this list. Defaults to None.
         ignore_attributes (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `object_results` that their each x position are in [`-max_x_position`, `max_x_position`]
+            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
+            for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
+        min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `object_results` that their each y position are in [`-max_y_position`, `max_y_position`]
+            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
+            for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
+        min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
             for both of their `estimated_object` and `ground_truth_object`. Defaults to None.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `object_results` that their each distance is smaller than `max_distance`
@@ -99,7 +107,9 @@ def filter_object_results(
             is_gt=False,
             target_labels=target_labels,
             max_x_position_list=max_x_position_list,
+            min_x_position_list=min_x_position_list,
             max_y_position_list=max_y_position_list,
+            min_y_position_list=min_y_position_list,
             max_distance_list=max_distance_list,
             min_distance_list=min_distance_list,
             confidence_threshold_list=confidence_threshold_list,
@@ -112,7 +122,9 @@ def filter_object_results(
                 target_labels=target_labels,
                 ignore_attributes=ignore_attributes,
                 max_x_position_list=max_x_position_list,
+                min_x_position_list=min_x_position_list,
                 max_y_position_list=max_y_position_list,
+                min_y_position_list=min_y_position_list,
                 max_distance_list=max_distance_list,
                 min_distance_list=min_distance_list,
                 min_point_numbers=min_point_numbers,
@@ -134,7 +146,9 @@ def filter_objects(
     target_labels: Optional[List[Label]] = None,
     ignore_attributes: Optional[List[str]] = None,
     max_x_position_list: Optional[List[float]] = None,
+    min_x_position_list: Optional[List[float]] = None,
     max_y_position_list: Optional[List[float]] = None,
+    min_y_position_list: Optional[List[float]] = None,
     max_distance_list: Optional[List[float]] = None,
     min_distance_list: Optional[List[float]] = None,
     min_point_numbers: Optional[List[int]] = None,
@@ -156,11 +170,15 @@ def filter_objects(
             Keep all `objects` that have same label in this list. Defaults to None.
         attributes_ignore (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `objects` that their each x position are in [`-max_x_position`, `max_x_position`].
+            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
             Defaults to None.
+        min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `objects` that their each y position are in [`-max_y_position`, `max_y_position`].
+            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
             Defaults to None.
+        min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `objects` that their each distance is smaller than `max_distance`. Defaults to None.
         min_distance_list (Optional[List[float]]): Thresholds list of minimum distance range from ego vehicle.
@@ -189,7 +207,9 @@ def filter_objects(
             target_labels=target_labels,
             ignore_attributes=ignore_attributes,
             max_x_position_list=max_x_position_list,
+            min_x_position_list=min_x_position_list,
             max_y_position_list=max_y_position_list,
+            min_y_position_list=min_y_position_list,
             max_distance_list=max_distance_list,
             min_distance_list=min_distance_list,
             min_point_numbers=min_point_numbers,
@@ -464,7 +484,9 @@ def _is_target_object(
     target_labels: Optional[List[LabelType]] = None,
     ignore_attributes: Optional[List[str]] = None,
     max_x_position_list: Optional[List[float]] = None,
+    min_x_position_list: Optional[List[float]] = None,
     max_y_position_list: Optional[List[float]] = None,
+    min_y_position_list: Optional[List[float]] = None,
     max_distance_list: Optional[List[float]] = None,
     min_distance_list: Optional[List[float]] = None,
     confidence_threshold_list: Optional[List[float]] = None,
@@ -483,11 +505,15 @@ def _is_target_object(
             Keep all `dynamic_object` that have same labels in this list. Defaults to None.
         ignore_attributes (Optional[List[str]]): List of attributes to be ignored. Defaults to None.
         max_x_position_list (Optional[List[float]]): Thresholds list of maximum x-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each x position are in [`-max_x_position`, `max_x_position`].
+            Keep all `dynamic_object` that their each x position is smaller than `max_x_position`.
             Defaults to None.
+        min_x_position_list (Optional[List[float]]): Thresholds list of minimum x-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each x position is bigger than `min_x_position`.
         max_y_position_list (Optional[List[float]]): Thresholds list of maximum y-axis position from ego vehicle.
-            Keep all `dynamic_object` that their each y position are in [`-max_y_position`, `max_y_position`].
+            Keep all `dynamic_object` that their each y position is smaller than `max_y_position`.
             Defaults to None.
+        min_y_position_list (Optional[List[float]]): Thresholds list of minimum y-axis position from ego vehicle.
+            Keep all `dynamic_object` that their each y position is bigger than `min_y_position`.
         max_distance_list (Optional[List[float]]): Thresholds list of maximum distance range from ego vehicle.
             Keep all `dynamic_object` that their each distance is smaller than `max_distance`. Defaults to None.
         min_distance_list (Optional[List[float]]): Thresholds list of minimum distance range from ego vehicle.
@@ -562,7 +588,15 @@ def _is_target_object(
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_x_position_list)
             )
-            is_target = is_target and abs(position_[0]) < max_x_position
+            is_target = is_target and position_[0] < max_x_position
+
+        if is_target and min_x_position_list is not None:
+            min_x_position = (
+                np.mean(min_x_position_list)
+                if use_unknown_threshold
+                else label_threshold.get_label_threshold(min_x_position_list)
+            )
+            is_target = is_target and position_[0] > min_x_position
 
         if is_target and max_y_position_list is not None:
             max_y_position = (
@@ -570,7 +604,15 @@ def _is_target_object(
                 if use_unknown_threshold
                 else label_threshold.get_label_threshold(max_y_position_list)
             )
-            is_target = is_target and abs(position_[1]) < max_y_position
+            is_target = is_target and position_[1] < max_y_position
+        
+        if is_target and min_y_position_list is not None:
+            min_y_position = (
+                np.mean(min_y_position_list)
+                if use_unknown_threshold
+                else label_threshold.get_label_threshold(min_y_position_list)
+            )
+            is_target = is_target and position_[1] > min_y_position
 
     if bev_distance_ is not None:
         if is_target and max_distance_list is not None:

--- a/perception_eval/perception_eval/tool/utils.py
+++ b/perception_eval/perception_eval/tool/utils.py
@@ -516,8 +516,8 @@ def filter_frame_by_region(
 
     Args:
         frame (PerceptionFrameResult): Frame result.
-        x_position (tuple[float, float], optional): x axis range. Defaults to None.
-        y_position (tuple[float, float], optional): y axis range. Defaults to None.
+        x_position (tuple[float, float], optional): x-axis range. Defaults to None.
+        y_position (tuple[float, float], optional): y-axis range. Defaults to None.
 
     Returns:
         PerceptionFrameResult: Filtered frame results.

--- a/perception_eval/perception_eval/tool/utils.py
+++ b/perception_eval/perception_eval/tool/utils.py
@@ -505,3 +505,58 @@ def filter_frame_by_distance(
     ret_frame.evaluate_frame()
 
     return ret_frame
+
+
+def filter_frame_by_region(
+    frame: PerceptionFrameResult,
+    axis_x: tuple[float, float] = None,
+    axis_y: tuple[float, float] = None,
+) -> PerceptionFrameResult:
+    """Filter frame results by region which is x axis and y axis.
+
+    Args:
+        frame (PerceptionFrameResult): Frame result.
+        axis_x (tuple[float, float], optional): x axis range. Defaults to None.
+        axis_y (tuple[float, float], optional): y axis range. Defaults to None.
+
+    Returns:
+        PerceptionFrameResult: Filtered frame results.
+    """
+    ret_frame = deepcopy(frame)
+
+    if axis_x is not None:
+        min_x_position_list = [axis_x[0]] * len(ret_frame.target_labels)
+        max_x_position_list = [axis_x[1]] * len(ret_frame.target_labels)
+    else:
+        min_x_position_list = None
+        max_x_position_list = None
+
+    if axis_y is not None:
+        min_y_position_list = [axis_y[0]] * len(ret_frame.target_labels)
+        max_y_position_list = [axis_y[1]] * len(ret_frame.target_labels)
+    else:
+        min_y_position_list = None
+        max_y_position_list = None
+
+    ret_frame.object_results = filter_object_results(
+        ret_frame.object_results,
+        target_labels=ret_frame.target_labels,
+        max_x_position_list=max_x_position_list,
+        min_x_position_list=min_x_position_list,
+        max_y_position_list=max_y_position_list,
+        min_y_position_list=min_y_position_list,
+        transforms=ret_frame.frame_ground_truth.transforms,
+    )
+    ret_frame.frame_ground_truth.objects = filter_objects(
+        ret_frame.frame_ground_truth.objects,
+        is_gt=True,
+        target_labels=ret_frame.target_labels,
+        max_x_position_list=max_x_position_list,
+        min_x_position_list=min_x_position_list,
+        max_y_position_list=max_y_position_list,
+        min_y_position_list=min_y_position_list,
+        transforms=ret_frame.frame_ground_truth.transforms,
+    )
+    ret_frame.evaluate_frame()
+
+    return ret_frame

--- a/perception_eval/perception_eval/tool/utils.py
+++ b/perception_eval/perception_eval/tool/utils.py
@@ -509,31 +509,31 @@ def filter_frame_by_distance(
 
 def filter_frame_by_region(
     frame: PerceptionFrameResult,
-    axis_x: tuple[float, float] = None,
-    axis_y: tuple[float, float] = None,
+    x_position: tuple[float, float] = None,
+    y_position: tuple[float, float] = None,
 ) -> PerceptionFrameResult:
     """Filter frame results by region which is x axis and y axis.
 
     Args:
         frame (PerceptionFrameResult): Frame result.
-        axis_x (tuple[float, float], optional): x axis range. Defaults to None.
-        axis_y (tuple[float, float], optional): y axis range. Defaults to None.
+        x_position (tuple[float, float], optional): x axis range. Defaults to None.
+        y_position (tuple[float, float], optional): y axis range. Defaults to None.
 
     Returns:
         PerceptionFrameResult: Filtered frame results.
     """
     ret_frame = deepcopy(frame)
 
-    if axis_x is not None:
-        min_x_position_list = [axis_x[0]] * len(ret_frame.target_labels)
-        max_x_position_list = [axis_x[1]] * len(ret_frame.target_labels)
+    if x_position is not None:
+        min_x_position_list = [x_position[0]] * len(ret_frame.target_labels)
+        max_x_position_list = [x_position[1]] * len(ret_frame.target_labels)
     else:
         min_x_position_list = None
         max_x_position_list = None
 
-    if axis_y is not None:
-        min_y_position_list = [axis_y[0]] * len(ret_frame.target_labels)
-        max_y_position_list = [axis_y[1]] * len(ret_frame.target_labels)
+    if y_position is not None:
+        min_y_position_list = [y_position[0]] * len(ret_frame.target_labels)
+        max_y_position_list = [y_position[1]] * len(ret_frame.target_labels)
     else:
         min_y_position_list = None
         max_y_position_list = None


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What
This PR enables to filter objects based on `region` from ego.
If only specify `max_x_position`, it works as usual.

<!-- Please describe what you changed. -->

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [x] test.perception_lsim
already checked by ci
<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference
- https://github.com/tier4/driving_log_replayer_v2/pull/68
- degradation check https://evaluation.ci.tier4.jp/evaluation/reports/4bef7c82-1343-5098-9475-e82e39c52083?project_id=prd_jt

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
