### PR TITLE
fix(perception): re-setting `__hash__` to use `__eq__`

### DIFF
--- a/perception_eval/perception_eval/common/evaluation_task.py
+++ b/perception_eval/perception_eval/common/evaluation_task.py
@@ -63,6 +63,9 @@ class EvaluationTask(Enum):
             return self.value == other
         return super().__eq__(other)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
     def is_3d(self) -> bool:
         return self in (
             EvaluationTask.DETECTION,

--- a/perception_eval/perception_eval/common/evaluation_task.py
+++ b/perception_eval/perception_eval/common/evaluation_task.py
@@ -64,7 +64,7 @@ class EvaluationTask(Enum):
         return super().__eq__(other)
 
     def __hash__(self) -> int:
-        return hash(self.value)
+        return super().__hash__()
 
     def is_3d(self) -> bool:
         return self in (

--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -97,6 +97,9 @@ class CommonLabel(Enum):
     def __eq__(self, label: LabelType) -> bool:
         return label in self.value
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def __str__(self) -> str:
         if self == CommonLabel.UNKNOWN:
             return "unknown"

--- a/perception_eval/perception_eval/common/schema.py
+++ b/perception_eval/perception_eval/common/schema.py
@@ -59,6 +59,9 @@ class FrameID(Enum):
             return self.value == __o
         return super().__eq__(__o)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def __str__(self) -> str:
         return self.value
 
@@ -143,6 +146,9 @@ class Visibility(Enum):
             return self.value == __o
         return super().__eq__(__o)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def __str__(self) -> str:
         return self.value
 
@@ -177,6 +183,9 @@ class SensorModality(Enum):
         if isinstance(__o, str):
             return self.value == __o
         return super().__eq__(__o)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
 
     def __str__(self) -> str:
         return self.value

--- a/perception_eval/perception_eval/common/shape.py
+++ b/perception_eval/perception_eval/common/shape.py
@@ -62,6 +62,9 @@ class ShapeType(Enum):
     def __eq__(self, other: Union[str, ShapeType]) -> bool:
         return self.value == other if isinstance(other, str) else super().__eq__(other)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
 
 class Shape:
     """Class for object's shape.

--- a/perception_eval/perception_eval/common/status.py
+++ b/perception_eval/perception_eval/common/status.py
@@ -34,6 +34,9 @@ class MatchingStatus(Enum):
             return self.value == other
         return super().__eq__(other)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def is_positive(self) -> bool:
         """Indicates whether current status is TP or FP.
 

--- a/perception_eval/perception_eval/tool/utils.py
+++ b/perception_eval/perception_eval/tool/utils.py
@@ -78,6 +78,9 @@ class PlotAxes(Enum):
             return self.value == other
         return super().__eq__(other)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def is_3d(self) -> bool:
         return self in (PlotAxes.POSITION, PlotAxes.SIZE, PlotAxes.VELOCITY, PlotAxes.POLAR)
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

This PR adds function `__hash__` in class based on `Enum` and having `__eq__`.

**Background**
The hash (return value by `hash()`) is `None` if the class overwrite `__eq__` and does not define `__hash__` .
This behavior causes it is impossible to use as key of dict.
So I made this PR.

reference: https://docs.python.org/3.13/reference/datamodel.html#object.__hash__

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed
Actually, there is no usecase to use hash now (like key of dict).

https://evaluation.ci.tier4.jp/evaluation/reports/af8b4abd-6042-5df2-838c-8286ea6363d4?project_id=prd_jt

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
