### PR TITLE
fix(perception): fix plane distance when there is yaw difference between gt and est

### DIFF
--- a/perception_eval/perception_eval/common/object.py
+++ b/perception_eval/perception_eval/common/object.py
@@ -312,9 +312,9 @@ class DynamicObject:
             return None
 
         def _clip(err: float) -> float:
-            """Clip [-2pi, 2pi] to [0, pi]"""
-            if err < 0:
-                err += -np.pi * (err // np.pi)
+            """Clip [-2pi, 2pi] to [-pi, pi]"""
+            if err < -np.pi:
+                err += 2 * np.pi
             elif err > np.pi:
                 err -= 2 * np.pi
             return err

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -313,7 +313,7 @@ class PlaneDistanceMatching(MatchingMethod):
             and ground_truth_object.state.shape_type == ShapeType.BOUNDING_BOX
         ):
             if estimated_object.get_heading_error(ground_truth_object) > np.pi / 2:
-                est_corners = est_corners[[1, 0, 3, 2, 1]] # based on reverse clockwise order from left top
+                est_corners = est_corners[[1, 0, 3, 2, 1]]  # based on reverse clockwise order from left top
 
             # Calculate min distance from ego vehicle
             if ground_truth_object.frame_id != FrameID.BASE_LINK:

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -312,6 +312,9 @@ class PlaneDistanceMatching(MatchingMethod):
             estimated_object.state.shape_type == ShapeType.BOUNDING_BOX
             and ground_truth_object.state.shape_type == ShapeType.BOUNDING_BOX
         ):
+            if estimated_object.get_heading_error(ground_truth_object) > np.pi / 2:
+                est_corners = est_corners[[1, 0, 3, 2, 1]] # based on reverse clockwise order from left top
+
             # Calculate min distance from ego vehicle
             if ground_truth_object.frame_id != FrameID.BASE_LINK:
                 assert transforms is not None, f"`transforms` must be specified for {ground_truth_object.frame_id}"

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -29,7 +29,6 @@ from perception_eval.common import ObjectType
 from perception_eval.common.label import is_same_label
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.point import get_point_left_right_index
-from perception_eval.common.point import get_point_left_right
 from perception_eval.common.point import polygon_to_list
 from perception_eval.common.schema import FrameID
 from perception_eval.common.shape import ShapeType
@@ -301,21 +300,6 @@ class PlaneDistanceMatching(MatchingMethod):
         if ground_truth_object is None:
             return None
 
-        def get_nearest_indices(object: DynamicObject, corners: np.ndarray) -> np.ndarray:
-            # Calculate min distance from ego vehicle
-            if object.frame_id != FrameID.BASE_LINK:
-                assert transforms is not None, f"`transforms` must be specified for {object.frame_id}"
-                gt_corners_base_link = np.array(
-                    [
-                        transforms.transform((object.frame_id, FrameID.BASE_LINK), corner)
-                        for corner in corners
-                    ]
-                )
-                distances = np.linalg.norm(gt_corners_base_link[:, :2], axis=1)
-            else:
-                distances = np.linalg.norm(corners[:, :2], axis=1)
-            return np.argsort(distances)
-
         # Get corner points of estimated object from footprint
         est_footprint: Polygon = estimated_object.get_footprint()
         est_corners = np.array(polygon_to_list(est_footprint))
@@ -328,33 +312,31 @@ class PlaneDistanceMatching(MatchingMethod):
             estimated_object.state.shape_type == ShapeType.BOUNDING_BOX
             and ground_truth_object.state.shape_type == ShapeType.BOUNDING_BOX
         ):
-            heading_difference = estimated_object.get_heading_error(ground_truth_object)
-            if heading_difference < np.pi / 4 or heading_difference > 3 * np.pi / 4:
-                if heading_difference > 3 * np.pi / 4:
-                    est_corners = est_corners[[1, 0, 3, 2, 1]] # flip based on reverse clockwise order from left top
+            if estimated_object.get_heading_error(ground_truth_object) > np.pi / 2:
+                est_corners = est_corners[[1, 0, 3, 2, 1]] # based on reverse clockwise order from left top
 
-                sort_idx = get_nearest_indices(ground_truth_object, gt_corners)
-                gt_corners = gt_corners[sort_idx]
-                est_corners = est_corners[sort_idx]
-
-                est_plane_points = est_corners[:2].tolist()
-                gt_plane_points = gt_corners[:2].tolist()
-
-                left_idx, right_idx = get_point_left_right_index(gt_plane_points[0], gt_plane_points[1])
-                gt_left_point, gt_right_point = gt_plane_points[left_idx], gt_plane_points[right_idx]
-                est_left_point, est_right_point = est_plane_points[left_idx], est_plane_points[right_idx]
+            # Calculate min distance from ego vehicle
+            if ground_truth_object.frame_id != FrameID.BASE_LINK:
+                assert transforms is not None, f"`transforms` must be specified for {ground_truth_object.frame_id}"
+                gt_corners_base_link = np.array(
+                    [
+                        transforms.transform((ground_truth_object.frame_id, FrameID.BASE_LINK), corner)
+                        for corner in gt_corners
+                    ]
+                )
+                gt_distances = np.linalg.norm(gt_corners_base_link[:, :2], axis=1)
             else:
-                sort_idx = get_nearest_indices(ground_truth_object, gt_corners)
-                gt_corners = gt_corners[sort_idx]
-                sort_idx = get_nearest_indices(estimated_object, est_corners)
-                est_corners = est_corners[sort_idx]
+                gt_distances = gt_distances = np.linalg.norm(gt_corners[:, :2], axis=1)
+            sort_idx = np.argsort(gt_distances)
 
-                est_plane_points = est_corners[:2].tolist()
-                gt_plane_points = gt_corners[:2].tolist()
+            gt_corners = gt_corners[sort_idx]
+            est_corners = est_corners[sort_idx]
 
-                est_left_point, est_right_point = get_point_left_right(est_plane_points[0], est_plane_points[1])
-                gt_left_point, gt_right_point = get_point_left_right(gt_plane_points[0], gt_plane_points[1])
-
+            est_plane_points = est_corners[:2].tolist()
+            gt_plane_points = gt_corners[:2].tolist()
+            left_idx, right_idx = get_point_left_right_index(gt_plane_points[0], gt_plane_points[1])
+            gt_left_point, gt_right_point = gt_plane_points[left_idx], gt_plane_points[right_idx]
+            est_left_point, est_right_point = est_plane_points[left_idx], est_plane_points[right_idx]
             distance_left_point: float = distance_points_bev(est_left_point, gt_left_point)
             distance_right_point: float = distance_points_bev(est_right_point, gt_right_point)
             distance_squared = distance_left_point**2 + distance_right_point**2

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -313,7 +313,7 @@ class PlaneDistanceMatching(MatchingMethod):
             and ground_truth_object.state.shape_type == ShapeType.BOUNDING_BOX
         ):
             _, _, error_yaw = estimated_object.get_heading_error(ground_truth_object)
-            if error_yaw > np.pi / 2:
+            if abs(error_yaw) > np.pi / 2:
                 est_corners = est_corners[[1, 0, 3, 2, 1]]  # based on reverse clockwise order from left top
 
             # Calculate min distance from ego vehicle

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -312,7 +312,8 @@ class PlaneDistanceMatching(MatchingMethod):
             estimated_object.state.shape_type == ShapeType.BOUNDING_BOX
             and ground_truth_object.state.shape_type == ShapeType.BOUNDING_BOX
         ):
-            if estimated_object.get_heading_error(ground_truth_object) > np.pi / 2:
+            _, _, error_yaw = estimated_object.get_heading_error(ground_truth_object)
+            if error_yaw > np.pi / 2:
                 est_corners = est_corners[[1, 0, 3, 2, 1]]  # based on reverse clockwise order from left top
 
             # Calculate min distance from ego vehicle


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

Flip the estimated object if yaw difference between GT and estimated object is bigger than 90 deg. (And fix how to calcurate yaw diff following code docs)

Before implementation, GT and estimated object are evaluated on same surface. But if there is large yaw difference(like 180 deg) between GT and estimated object, it is impossible to measure each nearest surface.

**Implementation Transfer Note**

Before https://github.com/tier4/autoware_perception_evaluation/pull/124
- measure each nearest surface
- there is probability that selection of nearest surface become unstable on each objects. 
  - assume GT and estimated object exist near w/o large error. It is possible to select the left surface on GT but select the right surface on estimated objects caused by ego and objects position.

After https://github.com/tier4/autoware_perception_evaluation/pull/124 before this PR
- measure nearest surface of GT and select same surface of GT on estimated objects
- If there is large yaw difference(like 180 deg) between GT and estimated object, it is impossible to measure each nearest surface.

<!-- Please describe what you changed. -->

**Remarks**
It might be good like below in terms of choosing the nearest surface (sample : [a48c5df](https://github.com/tier4/autoware_perception_evaluation/pull/208/commits/a48c5df62e1e68c03b94f28a3959b1db885c3851))
premise : Nearest surface is determined by GT, Error range is 0 ~ 180 deg
**Condition1.** yaw difference < 45 deg
Nearest surface of estimated objects is same as GT
**Condition2.** 45 deg < yaw difference < 135 deg
Nearest surface of estimated objects is determined by calcurate self corners
**Condition3.** 135 deg < yaw difference
Nearest surface of estimated objects is same as GT after flip estimated objects

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

https://evaluation.ci.tier4.jp/evaluation/reports/cd5eafed-4246-59fd-a9dd-a78f6c408050?project_id=prd_jt

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
