### PR TITLE
fix(perception): fix plane distance about bbox dimension when there is yaw difference between gt and est

### DIFF
--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -314,7 +314,7 @@ class PlaneDistanceMatching(MatchingMethod):
         ):
             _, _, error_yaw = estimated_object.get_heading_error(ground_truth_object)
             if abs(error_yaw) > np.pi / 2:
-                est_corners = est_corners[[1, 0, 3, 2, 1]]  # based on reverse clockwise order from left top
+                est_corners = est_corners[[2, 3, 0, 1]]  # based on reverse clockwise order from left top
 
             # Calculate min distance from ego vehicle
             if ground_truth_object.frame_id != FrameID.BASE_LINK:
@@ -327,7 +327,7 @@ class PlaneDistanceMatching(MatchingMethod):
                 )
                 gt_distances = np.linalg.norm(gt_corners_base_link[:, :2], axis=1)
             else:
-                gt_distances = gt_distances = np.linalg.norm(gt_corners[:, :2], axis=1)
+                gt_distances = np.linalg.norm(gt_corners[:, :2], axis=1)
             sort_idx = np.argsort(gt_distances)
 
             gt_corners = gt_corners[sort_idx]


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

This PR fix calcuration of plane_distance caused by https://github.com/tier4/autoware_perception_evaluation/pull/208.
And chore (corners do not need to add first points) and delete unnecessary assignment.

Description is below image.
If there is yaw difference of pi/2, it is necessary to align the order of gt corners. but I do not consider it (concretely correct implementation is reverse-rclockwise from the upper left, but my implementation is clockwise from the upper right.).
![image](https://github.com/user-attachments/assets/68f498e5-77ad-44fc-bfb3-503cd37335ea)


## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
