### PR TITLE
fix(perception): fix how to count FP and TN in fp_validation and add method to get number of GT

### DIFF
--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -275,15 +275,8 @@ def get_positive_objects(
 
         if est_status == MatchingStatus.FP:
             if gt_status == MatchingStatus.TN:
-                fp_object_results.append(
-                    DynamicObjectWithPerceptionResult(
-                        object_result.estimated_object,
-                        None,
-                        object_result.matching_label_policy,
-                    )
-                )
-            else:
-                fp_object_results.append(object_result)
+                continue
+            fp_object_results.append(object_result)
         elif est_status == MatchingStatus.TP and gt_status == MatchingStatus.TP:
             tp_object_results.append(object_result)
 

--- a/perception_eval/perception_eval/evaluation/result/object_result.py
+++ b/perception_eval/perception_eval/evaluation/result/object_result.py
@@ -125,13 +125,13 @@ class DynamicObjectWithPerceptionResult:
 
         if self.is_result_correct(matching_mode, matching_threshold):
             return (
-                (MatchingStatus.FP, MatchingStatus.TN)
+                (MatchingStatus.FP, MatchingStatus.FP)
                 if self.ground_truth_object.semantic_label.is_fp()
                 else (MatchingStatus.TP, MatchingStatus.TP)
             )
         else:
             return (
-                (MatchingStatus.FP, MatchingStatus.FP)
+                (MatchingStatus.FP, MatchingStatus.TN)
                 if self.ground_truth_object.semantic_label.is_fp()
                 else (MatchingStatus.FP, MatchingStatus.FN)
             )

--- a/perception_eval/perception_eval/evaluation/result/object_result.py
+++ b/perception_eval/perception_eval/evaluation/result/object_result.py
@@ -125,13 +125,13 @@ class DynamicObjectWithPerceptionResult:
 
         if self.is_result_correct(matching_mode, matching_threshold):
             return (
-                (MatchingStatus.FP, MatchingStatus.FP)
+                (MatchingStatus.FP, MatchingStatus.TN)
                 if self.ground_truth_object.semantic_label.is_fp()
                 else (MatchingStatus.TP, MatchingStatus.TP)
             )
         else:
             return (
-                (MatchingStatus.FP, MatchingStatus.TN)
+                (MatchingStatus.FP, MatchingStatus.FP)
                 if self.ground_truth_object.semantic_label.is_fp()
                 else (MatchingStatus.FP, MatchingStatus.FN)
             )

--- a/perception_eval/perception_eval/evaluation/result/perception_pass_fail_result.py
+++ b/perception_eval/perception_eval/evaluation/result/perception_pass_fail_result.py
@@ -107,6 +107,17 @@ class PassFailResult:
         """
         return len(self.fp_object_results) + len(self.fn_objects)
 
+    def get_num_gt(self) -> int:
+        """Get the number of ground truth objects.
+
+        Returns:
+            int: Number of ground truth objects.
+        """
+        if self.frame_pass_fail_config.evaluation_task.is_fp_validation():
+            return len(self.fp_object_results) + len(self.tn_objects)
+        else:
+            return len(self.tp_object_results) + len(self.fn_objects)
+
     def get_fail_object_num(self) -> int:
         """Get the number of fail objects.
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
  - [x] fp_validation
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->

This PR fixes how to count FP and TN in fp_validation.
And add method to get number of GT.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
