### PR TITLE
fix: compute matchable threshold from estimation label if gt label is FP

### DIFF
--- a/perception_eval/perception_eval/common/threshold.py
+++ b/perception_eval/perception_eval/common/threshold.py
@@ -258,7 +258,7 @@ def check_thresholds(thresholds: List[Real], num_elements: int) -> List[Real]:
         raise ThresholdError(f"Type of all elements must be Real number, but got {thresholds}")
     elif len(thresholds) != num_elements:
         raise ThresholdError(
-            f"Expected the number of elements is {num_elements}, " f"but got {len(thresholds)}",
+            f"Expected the number of elements is {num_elements}, but got {len(thresholds)}",
         )
     return thresholds
 

--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -271,12 +271,11 @@ def get_positive_objects(
             else object_result.ground_truth_object.semantic_label
         )
 
-        matching_threshold = get_label_threshold(
+        matching_threshold: Optional[float] = get_label_threshold(
             semantic_label=semantic_label,
             target_labels=target_labels,
             threshold_list=matching_threshold_list,
         )
-
         est_status, gt_status = object_result.get_status(matching_mode, matching_threshold)
 
         if est_status == MatchingStatus.FP:
@@ -327,15 +326,13 @@ def get_negative_objects(
     for object_result in object_results:
         # to get label threshold, use GT label basically,
         # but use EST label if GT is FP validation
+        semantic_label = (
+            object_result.estimated_object.semantic_label
+            if (object_result.ground_truth_object is None or object_result.ground_truth_object.semantic_label.is_fp())
+            else object_result.ground_truth_object.semantic_label
+        )
         matching_threshold: Optional[float] = get_label_threshold(
-            (
-                object_result.estimated_object.semantic_label
-                if (
-                    object_result.ground_truth_object is None
-                    or object_result.ground_truth_object.semantic_label.is_fp()
-                )
-                else object_result.ground_truth_object.semantic_label
-            ),
+            semantic_label,
             target_labels,
             matching_threshold_list,
         )
@@ -408,10 +405,15 @@ def divide_tp_fp_objects(
             fp_object_results.append(object_result)
             continue
 
-        # in case of matching (Est, GT) = (unknown, except of unknown)
-        # use GT label
+        # to get label threshold, use GT label basically,
+        # but use EST label if GT is FP validation
+        semantic_label = (
+            object_result.estimated_object.semantic_label
+            if object_result.ground_truth_object.semantic_label.is_fp()
+            else object_result.ground_truth_object.semantic_label
+        )
         matching_threshold_ = get_label_threshold(
-            semantic_label=object_result.ground_truth_object.semantic_label,
+            semantic_label=semantic_label,
             target_labels=target_labels,
             threshold_list=matching_threshold_list,
         )

--- a/perception_eval/perception_eval/evaluation/matching/objects_filter.py
+++ b/perception_eval/perception_eval/evaluation/matching/objects_filter.py
@@ -263,10 +263,16 @@ def get_positive_objects(
             fp_object_results.append(object_result)
             continue
 
-        # in case of matching (Est, GT) = (unknown, except of unknown)
-        # use GT label
+        # to get label threshold, use GT label basically,
+        # but use EST label if GT is FP validation
+        semantic_label = (
+            object_result.estimated_object.semantic_label
+            if object_result.ground_truth_object.semantic_label.is_fp()
+            else object_result.ground_truth_object.semantic_label
+        )
+
         matching_threshold = get_label_threshold(
-            semantic_label=object_result.ground_truth_object.semantic_label,
+            semantic_label=semantic_label,
             target_labels=target_labels,
             threshold_list=matching_threshold_list,
         )
@@ -319,11 +325,16 @@ def get_negative_objects(
 
     non_candidates: List[ObjectType] = []
     for object_result in object_results:
+        # to get label threshold, use GT label basically,
+        # but use EST label if GT is FP validation
         matching_threshold: Optional[float] = get_label_threshold(
             (
-                object_result.ground_truth_object.semantic_label
-                if object_result.ground_truth_object is not None
-                else object_result.estimated_object.semantic_label
+                object_result.estimated_object.semantic_label
+                if (
+                    object_result.ground_truth_object is None
+                    or object_result.ground_truth_object.semantic_label.is_fp()
+                )
+                else object_result.ground_truth_object.semantic_label
             ),
             target_labels,
             matching_threshold_list,

--- a/perception_eval/perception_eval/evaluation/metrics/detection/ap.py
+++ b/perception_eval/perception_eval/evaluation/metrics/detection/ap.py
@@ -255,10 +255,15 @@ class Ap:
         fp_list: List[float] = [0.0 for _ in range(self.objects_results_num)]
 
         for i, obj_result in enumerate(object_results):
+            # to get label threshold, use GT label basically,
+            # but use EST label if GT is FP validation
+            semantic_label = (
+                obj_result.estimated_object.semantic_label
+                if (obj_result.ground_truth_object is None or obj_result.ground_truth_object.semantic_label.is_fp())
+                else obj_result.ground_truth_object.semantic_label
+            )
             matching_threshold_ = get_label_threshold(
-                semantic_label=obj_result.ground_truth_object.semantic_label
-                if obj_result.ground_truth_object is not None
-                else obj_result.estimated_object.semantic_label,
+                semantic_label=semantic_label,
                 target_labels=self.target_labels,
                 threshold_list=self.matching_threshold_list,
             )

--- a/perception_eval/perception_eval/evaluation/metrics/tracking/clear.py
+++ b/perception_eval/perception_eval/evaluation/metrics/tracking/clear.py
@@ -172,10 +172,18 @@ class CLEAR(_TrackingMetricsBase):
 
         for cur_obj_result in cur_object_results:
             # Assign previous results if same matching pair has
-            matching_threshold_: float = get_label_threshold(
-                semantic_label=cur_obj_result.ground_truth_object.semantic_label
-                if cur_obj_result.ground_truth_object is not None
-                else cur_obj_result.estimated_object.semantic_label,
+            # to get label threshold, use GT label basically,
+            # but use EST label if GT is FP validation
+            semantic_label = (
+                cur_obj_result.estimated_object.semantic_label
+                if (
+                    cur_obj_result.ground_truth_object is None
+                    or cur_obj_result.ground_truth_object.semantic_label.is_fp()
+                )
+                else cur_obj_result.ground_truth_object.semantic_label
+            )
+            matching_threshold_ = get_label_threshold(
+                semantic_label=semantic_label,
                 target_labels=self.target_labels,
                 threshold_list=self.matching_threshold_list,
             )

--- a/perception_eval/perception_eval/evaluation/result/object_result.py
+++ b/perception_eval/perception_eval/evaluation/result/object_result.py
@@ -526,7 +526,9 @@ def _get_object_results_for_tlr(
     return object_results
 
 
-def _get_fp_object_results(estimated_objects: List[ObjectType]) -> List[DynamicObjectWithPerceptionResult]:
+def _get_fp_object_results(
+    estimated_objects: List[ObjectType],
+) -> List[DynamicObjectWithPerceptionResult]:
     """Returns the list of DynamicObjectWithPerceptionResult that have no ground truth.
 
     Args:
@@ -603,8 +605,18 @@ def _get_score_table(
             is_same_frame_id: bool = est_obj.frame_id == gt_obj.frame_id
 
             if is_same_frame_id:
-                threshold: Optional[float] = get_label_threshold(
-                    gt_obj.semantic_label, target_labels, matchable_thresholds
+                threshold: Optional[float] = (
+                    get_label_threshold(
+                        est_obj.semantic_label,
+                        target_labels,
+                        matchable_thresholds,
+                    )
+                    if gt_obj.semantic_label.is_fp()
+                    else get_label_threshold(
+                        gt_obj.semantic_label,
+                        target_labels,
+                        matchable_thresholds,
+                    )
                 )
 
                 matching_method: MatchingMethod = matching_method_module(


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [ ] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
  - [x] FP validation 
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->

This PR fixes the way of retrieving matchable threshold when GT label is `false_positive`.

In the case of GT  label is `false_positive`, we try to get matchable threshold by comparing the label of estimated object.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
