### PR TITLE
fix(perception): use `Frame.ID` instead of `str` in interpolation method

### DIFF
--- a/perception_eval/perception_eval/manager/_evaluation_manager_base.py
+++ b/perception_eval/perception_eval/manager/_evaluation_manager_base.py
@@ -21,6 +21,7 @@ from perception_eval.common.dataset import FrameGroundTruth
 from perception_eval.common.dataset import get_interpolated_now_frame
 from perception_eval.common.dataset import get_now_frame
 from perception_eval.common.dataset import load_all_datasets
+from perception_eval.common.schema import FrameID
 from perception_eval.config import EvaluationConfigType
 from perception_eval.evaluation import FrameResultType
 from perception_eval.visualization import VisualizerType
@@ -93,6 +94,7 @@ class _EvaluationMangerBase(ABC):
         unix_time: int,
         threshold_min_time: int = 75000,
         interpolate_ground_truth: bool = False,
+        interpolated_frame_id: FrameID = FrameID.MAP,
     ) -> Optional[FrameGroundTruth]:
         """Returns a FrameGroundTruth instance that has the closest timestamp with `unix_time`.
 
@@ -120,6 +122,7 @@ class _EvaluationMangerBase(ABC):
                 ground_truth_frames=self.ground_truth_frames,
                 unix_time=unix_time,
                 threshold_min_time=threshold_min_time,
+                return_frame_id=interpolated_frame_id,
             )
             return ground_truth_now_frame
 


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [x] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

This PR get to use `Frame.ID` instead of `str` in interpolation method

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
