### PR TITLE
fix(perception): delete unnecessary count up method in `LabelConverter`

### DIFF
--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -268,7 +268,7 @@ class LabelConverter:
             label (str): Label name you want to convert to any LabelType object.
 
         Returns:
-            Label: Converted label.
+            LabelType: Converted label.
         """
         return_label: Optional[LabelType] = None
         for label_info in self.label_infos:

--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -196,6 +196,8 @@ class LabelConverter:
                 - BUS, TRUCK, TRAILER -> CAR
                 - MOTORBIKE, CYCLIST -> BICYCLE
         label_prefix (str): Prefix of label, [autoware, traffic_light]. Defaults to autoware.
+        count_label_number (bool): Whether to count how many labels have been converted.
+            Defaults to False.
 
     Raises:
         NotImplementedError: For prefix named `blinker` and `brake_lamp` is under construction.
@@ -240,8 +242,7 @@ class LabelConverter:
 
         Args:
             label (str): Label name you want to convert to any LabelType object.
-            count_label_number (bool): Whether to count how many labels have been converted.
-                Defaults to False.
+            attributes (List[str]): List of attributes. Defaults to [].
 
         Returns:
             Label: Converted label.
@@ -260,13 +261,11 @@ class LabelConverter:
             return_label = Label(self.label_type.UNKNOWN, name, attributes)
         return return_label
 
-    def convert_name(self, name: str) -> LabelType:
-        """Convert label name to LabelType instance.
+    def convert_name_without_count(self, name: str) -> LabelType:
+        """Convert only label name to LabelType instance without counting even if `count_label_number` is True.
 
         Args:
             label (str): Label name you want to convert to any LabelType object.
-            count_label_number (bool): Whether to count how many labels have been converted.
-                Defaults to False.
 
         Returns:
             Label: Converted label.
@@ -274,8 +273,6 @@ class LabelConverter:
         return_label: Optional[LabelType] = None
         for label_info in self.label_infos:
             if name.lower() == label_info.name:
-                if self.count_label_number:
-                    label_info.num += 1
                 return_label = label_info.label
         if return_label is None:
             logging.warning(f"Label {name} is not registered.")
@@ -445,7 +442,7 @@ def set_target_lists(
     """
     if target_labels is None or len(target_labels) == 0:
         return [label for label in label_converter.label_type]
-    return [label_converter.convert_name(name) for name in target_labels]
+    return [label_converter.convert_name_without_count(name) for name in target_labels]
 
 
 def is_same_label(object1: ObjectType, object2: ObjectType) -> bool:

--- a/perception_eval/perception_eval/visualization/eda_tool.py
+++ b/perception_eval/perception_eval/visualization/eda_tool.py
@@ -475,7 +475,7 @@ class EDAManager:
             confidence_threshold (float):
                     confidence threshold for visualization
         """
-        target_labels: List[LabelType] = [self.label_converter.convert_name(name) for name in self.class_names]
+        target_labels: List[LabelType] = [self.label_converter.convert_name_without_count(name) for name in self.class_names]
         # visualize tp, fp in estimated objects
         tp_results, fp_results = divide_tp_fp_objects(
             object_results,

--- a/perception_eval/perception_eval/visualization/eda_tool.py
+++ b/perception_eval/perception_eval/visualization/eda_tool.py
@@ -475,7 +475,9 @@ class EDAManager:
             confidence_threshold (float):
                     confidence threshold for visualization
         """
-        target_labels: List[LabelType] = [self.label_converter.convert_name_without_count(name) for name in self.class_names]
+        target_labels: List[LabelType] = [
+            self.label_converter.convert_name_without_count(name) for name in self.class_names
+        ]
         # visualize tp, fp in estimated objects
         tp_results, fp_results = divide_tp_fp_objects(
             object_results,

--- a/perception_eval/test/common/test_label.py
+++ b/perception_eval/test/common/test_label.py
@@ -123,4 +123,4 @@ def test_label_converter(
         count_label_number=True,
     )
     for autoware_label, name in label_pairs:
-        assert autoware_label == label_converter.convert_name(name)
+        assert autoware_label == label_converter.convert_name_without_count(name)


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [x] Detection
  - [x] Tracking
  - [x] Prediction
  - [x] Classification
- [ ] Sensing
- [ ] Other

## What

This PR fixes the number of GTs when finished loading dataset.

In previous, use `LabelConverter.convert_name` to load just target_labels. (https://github.com/tier4/autoware_perception_evaluation/blob/develop/perception_eval/perception_eval/config/perception_evaluation_config.py#L134) But then the number of GTs was increased fraudulently.

In order to fix this problem, I performed below things.
- Do not count up in `convert_name`
  - `convert_label` and `convert_name` is similar function. Therefore, I changed it to a function that can be used for different purposes. 
- change the function name from `convert_name` to `convert_name_without_count` to be the  clearer


<!-- Please describe what you changed. -->

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
