### PR TITLE
feat(perception): add pass_fail_result for pickle

### DIFF
--- a/perception_eval/perception_eval/evaluation/result/perception_frame_result.py
+++ b/perception_eval/perception_eval/evaluation/result/perception_frame_result.py
@@ -218,7 +218,7 @@ class PerceptionFrameResult:
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """Set the state of the object after deserialization."""
-        self.pass_fail_result = state["pass_fail_result"]
+        self.pass_fail_result = state.get("pass_fail_result", None)
 
     def serialization(self) -> Dict[str, Any]:
         """Serialize the object to a dict."""

--- a/perception_eval/perception_eval/evaluation/result/perception_frame_result.py
+++ b/perception_eval/perception_eval/evaluation/result/perception_frame_result.py
@@ -203,19 +203,22 @@ class PerceptionFrameResult:
 
     def __reduce__(self) -> Tuple[PerceptionFrameResult, Tuple[Any]]:
         """Serialization and deserialization of the object with pickling."""
-        return (
-            self.__class__,
-            (
-                self.object_results,
-                self.nuscene_object_results,
-                self.frame_ground_truth,
-                self.metrics_config,
-                self.critical_object_filter_config,
-                self.frame_pass_fail_config,
-                self.unix_time,
-                self.target_labels,
-            ),
+        init_args = (
+            self.object_results,
+            self.nuscene_object_results,
+            self.frame_ground_truth,
+            self.metrics_config,
+            self.critical_object_filter_config,
+            self.frame_pass_fail_config,
+            self.unix_time,
+            self.target_labels,
         )
+        state = {"pass_fail_result": self.pass_fail_result}
+        return (self.__class__, init_args, state)
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """Set the state of the object after deserialization."""
+        self.pass_fail_result = state["pass_fail_result"]
 
     def serialization(self) -> Dict[str, Any]:
         """Serialize the object to a dict."""


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [ ] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [x] Other

## What

This PR adds `self.pass_fail_result` in `PerceptionFrameResult` for pickle.

In perception_eval, it is possible to analyze perception using pickled `PerceptionFrameResult` ([docs](https://github.com/tier4/autoware_perception_evaluation/blob/develop/docs/en/perception/analyzer.md#how-to-use)). But if not exist (save) `self.pass_fail_result` in it, impossible to re-generate the result. So I added this instance variable.

Note that we will deal with the pickling of PassFailResult later, as it is complicated.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
