### PR TITLE
fix: add simple escape in mkdir sequense

### DIFF
--- a/perception_eval/perception_eval/config/_evaluation_config_base.py
+++ b/perception_eval/perception_eval/config/_evaluation_config_base.py
@@ -128,7 +128,9 @@ class _EvaluationConfigBase(ABC):
             try:
                 os.makedirs(self.visualization_directory)
             except OSError as e:
-                logging.exception(f"Failed to create visualization directory: {self.visualization_directory}. Error: {e}")
+                logging.exception(
+                    f"Failed to create visualization directory: {self.visualization_directory}. Error: {e}"
+                )
 
     def __reduce__(self) -> Tuple[_EvaluationConfigBase, Tuple[Any]]:
         """Serialization and deserialization of the object with pickling."""

--- a/perception_eval/perception_eval/config/_evaluation_config_base.py
+++ b/perception_eval/perception_eval/config/_evaluation_config_base.py
@@ -127,7 +127,6 @@ class _EvaluationConfigBase(ABC):
             except Exception as e:
                 print(e)
 
-
     def __reduce__(self) -> Tuple[_EvaluationConfigBase, Tuple[Any]]:
         """Serialization and deserialization of the object with pickling."""
         return (

--- a/perception_eval/perception_eval/config/_evaluation_config_base.py
+++ b/perception_eval/perception_eval/config/_evaluation_config_base.py
@@ -117,9 +117,16 @@ class _EvaluationConfigBase(ABC):
         self.__log_directory: str = osp.join(self.result_root_directory, "log")
         self.__visualization_directory: str = osp.join(self.result_root_directory, "visualization")
         if not osp.exists(self.log_directory):
-            os.makedirs(self.log_directory)
+            try:
+                os.makedirs(self.log_directory)
+            except Exception as e:
+                print(e)
         if not osp.exists(self.visualization_directory):
-            os.makedirs(self.visualization_directory)
+            try:
+                os.makedirs(self.visualization_directory)
+            except Exception as e:
+                print(e)
+
 
     def __reduce__(self) -> Tuple[_EvaluationConfigBase, Tuple[Any]]:
         """Serialization and deserialization of the object with pickling."""

--- a/perception_eval/perception_eval/config/_evaluation_config_base.py
+++ b/perception_eval/perception_eval/config/_evaluation_config_base.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from abc import ABC
 from abc import abstractmethod
 import datetime
+import logging
 import os
 import os.path as osp
 from typing import Any
@@ -116,16 +117,18 @@ class _EvaluationConfigBase(ABC):
         self.result_root_directory: str = result_root_directory.format(TIME=time)
         self.__log_directory: str = osp.join(self.result_root_directory, "log")
         self.__visualization_directory: str = osp.join(self.result_root_directory, "visualization")
+        # create directories if not exist.
+        # it may cause permission error, so use try-catch to handle it.
         if not osp.exists(self.log_directory):
             try:
                 os.makedirs(self.log_directory)
-            except Exception as e:
-                print(e)
+            except OSError as e:
+                logging.exception(f"Failed to create log directory: {self.log_directory}. Error: {e}")
         if not osp.exists(self.visualization_directory):
             try:
                 os.makedirs(self.visualization_directory)
-            except Exception as e:
-                print(e)
+            except OSError as e:
+                logging.exception(f"Failed to create visualization directory: {self.visualization_directory}. Error: {e}")
 
     def __reduce__(self) -> Tuple[_EvaluationConfigBase, Tuple[Any]]:
         """Serialization and deserialization of the object with pickling."""


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->
Described in https://github.com/tier4/autoware_perception_evaluation/issues/236.
`mkdir` statement want to create invalid or permission-denied folder even during loading pickle file.

This PR is quick fix for reading pickle file issue.

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
