### PR TITLE
feat(perception): add new matching method allow_same_group

### DIFF
--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -579,9 +579,6 @@ def is_same_label_group(object1: ObjectType, object2: ObjectType) -> bool:
     -------
         bool: Return True if both labels are in the same label group.
     """
-    if not isinstance(object1.semantic_label, AutowareLabel) or not isinstance(object2.semantic_label, AutowareLabel):
-        raise ValueError("Both labels must be AutowareLabel.")
-
     if object1.semantic_label == object2.semantic_label:
         return True
     else:

--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -66,6 +66,14 @@ class AutowareLabel(Enum):
         """Deserialize the data to AutowareLabel."""
         return cls(data["value"])
 
+    def is_in_vehicle_labels(self) -> bool:
+        """Return whether myself is in vehicle labels."""
+        return self in [AutowareLabel.CAR, AutowareLabel.TRUCK, AutowareLabel.BUS]
+
+    def is_in_vru_labels(self) -> bool:
+        """Return whether myself is in VRU labels."""
+        return self in [AutowareLabel.BICYCLE, AutowareLabel.MOTORBIKE, AutowareLabel.PEDESTRIAN]
+
 
 class TrafficLightLabel(Enum):
     # except of classification
@@ -210,6 +218,18 @@ class Label:
             bool: Whether myself is `unknown`.
         """
         return self.label == CommonLabel.UNKNOWN
+
+    def is_in_vehicle_labels(self) -> bool:
+        """Return whether myself is in vehicle labels."""
+        if isinstance(self.label, AutowareLabel):
+            return self.label.is_in_vehicle_labels()
+        raise ValueError(f"Unexpected label type: {type(self.label)}")
+
+    def is_in_vru_labels(self) -> bool:
+        """Return whether myself is in VRU labels."""
+        if isinstance(self.label, AutowareLabel):
+            return self.label.is_in_vru_labels()
+        raise ValueError(f"Unexpected label type: {type(self.label)}")
 
     def __eq__(self, other: Label) -> bool:
         return self.label == other.label
@@ -542,3 +562,31 @@ def is_same_label(object1: ObjectType, object2: ObjectType) -> bool:
         bool: Return True if both labels are same.
     """
     return object1.semantic_label == object2.semantic_label
+
+
+def is_same_label_group(object1: ObjectType, object2: ObjectType) -> bool:
+    """Indicate whether both objects have same label group.
+
+    For example, if the label is AutowareLabel, the label group is determined by the value of the label.
+    If both labels are AutowareLabel.CAR, AutowareLabel.BUS, or AutowareLabel.TRUCK, they are considered to be in the same label group.
+
+    Args:
+    ----
+        object1 (ObjectType): An object.
+        object2 (ObjectType): An object.
+
+    Returns:
+    -------
+        bool: Return True if both labels are in the same label group.
+    """
+    if not isinstance(object1.semantic_label, AutowareLabel) or not isinstance(object2.semantic_label, AutowareLabel):
+        raise ValueError("Both labels must be AutowareLabel.")
+
+    if object1.semantic_label == object2.semantic_label:
+        return True
+    else:
+        if object1.semantic_label.is_in_vehicle_labels() and object2.semantic_label.is_in_vehicle_labels():
+            return True
+        elif object1.semantic_label.is_in_vru_labels() and object2.semantic_label.is_in_vru_labels():
+            return True
+    return False

--- a/perception_eval/perception_eval/config/perception_evaluation_config.py
+++ b/perception_eval/perception_eval/config/perception_evaluation_config.py
@@ -107,11 +107,14 @@ class PerceptionEvaluationConfig(_EvaluationConfigBase):
                 MatchingLabelPolicy.ALLOW_UNKNOWN if allow_matching_unknown else MatchingLabelPolicy.DEFAULT
             )
 
-        # If using MatchingLabelPolicy.ALLOW_UNKNOWN, it is required unknown label in target label
-        if matching_label_policy is MatchingLabelPolicy.ALLOW_UNKNOWN and "unknown" not in e_cfg.get(
-            "target_labels", []
-        ):
-            raise ValueError("MatchingLabelPolicy.ALLOW_UNKNOWN requires 'unknown' to be included in target_labels")
+        # If using MatchingLabelPolicy.ALLOW_UNKNOWN or MatchingLabelPolicy.ALLOW_SAME_GROUP, it is required unknown label in target label
+        if matching_label_policy in (
+            MatchingLabelPolicy.ALLOW_UNKNOWN,
+            MatchingLabelPolicy.ALLOW_SAME_GROUP,
+        ) and "unknown" not in e_cfg.get("target_labels", []):
+            raise ValueError(
+                "MatchingLabelPolicy.ALLOW_UNKNOWN or MatchingLabelPolicy.ALLOW_SAME_GROUP requires 'unknown' to be included in target_labels"
+            )
 
         l_params: Dict[str, Any] = {
             "label_prefix": e_cfg["label_prefix"],

--- a/perception_eval/perception_eval/evaluation/matching/object_matching.py
+++ b/perception_eval/perception_eval/evaluation/matching/object_matching.py
@@ -28,6 +28,7 @@ from perception_eval.common import distance_objects_bev
 from perception_eval.common import distance_points_bev
 from perception_eval.common import ObjectType
 from perception_eval.common.label import is_same_label
+from perception_eval.common.label import is_same_label_group
 from perception_eval.common.object import DynamicObject
 from perception_eval.common.point import get_point_left_right_index
 from perception_eval.common.point import polygon_to_list
@@ -39,6 +40,7 @@ from shapely.geometry import Polygon
 
 class MatchingLabelPolicy(Enum):
     DEFAULT = "DEFAULT"
+    ALLOW_SAME_GROUP = "ALLOW_SAME_GROUP"
     ALLOW_UNKNOWN = "ALLOW_UNKNOWN"
     ALLOW_ANY = "ALLOW_ANY"
 
@@ -70,6 +72,8 @@ class MatchingLabelPolicy(Enum):
             return True
         elif self == MatchingLabelPolicy.ALLOW_UNKNOWN:
             return is_same_label(estimation, ground_truth) or estimation.semantic_label.is_unknown()
+        elif self == MatchingLabelPolicy.ALLOW_SAME_GROUP:
+            return is_same_label_group(estimation, ground_truth) or estimation.semantic_label.is_unknown()
         else:  # STRICT
             return is_same_label(estimation, ground_truth)
 

--- a/perception_eval/test/config/test_perception_evaluation_config.py
+++ b/perception_eval/test/config/test_perception_evaluation_config.py
@@ -99,6 +99,8 @@ class TestPerceptionEvaluationConfig(unittest.TestCase):
             ({"matching_label_policy": "allow_unknown"}, MatchingLabelPolicy.ALLOW_UNKNOWN),
             ({"matching_label_policy": "ALLOW_ANY"}, MatchingLabelPolicy.ALLOW_ANY),
             ({"matching_label_policy": "allow_any"}, MatchingLabelPolicy.ALLOW_ANY),
+            ({"matching_label_policy": "ALLOW_SAME_GROUP"}, MatchingLabelPolicy.ALLOW_SAME_GROUP),
+            ({"matching_label_policy": "allow_same_group"}, MatchingLabelPolicy.ALLOW_SAME_GROUP),
         ]
         for n, (policy, expect) in enumerate(patterns):
             with self.subTest(f"Test case: {n + 1}"):

--- a/perception_eval/test/evaluation/result/test_object_result.py
+++ b/perception_eval/test/evaluation/result/test_object_result.py
@@ -277,3 +277,77 @@ class TestObjectResult(unittest.TestCase):
                     assert est_label == result.estimated_object.semantic_label
                     assert gt_label == result.ground_truth_object.semantic_label
                     assert is_label_correct == result.is_label_correct
+
+    def test_matching_label_policy_allow_same_group(self) -> None:
+        """Test retrieving object results with `MatchingLabelPolicy.ALLOW_SAME_GROUP`.
+
+        Patterns:
+        --------
+            1. Est: (CAR, BICYCLE, CAR), GT: (CAR, BICYCLE, CAR)
+                -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (CAR, CAR)]
+            2. Est: (CAR, BICYCLE, UNKNOWN), GT: (CAR, BICYCLE, CAR)
+                -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (UNKNOWN, CAR)]
+            3. Est: (CAR, BICYCLE, PEDESTRIAN), GT: (CAR, BICYCLE, CAR)
+                -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (PEDESTRIAN, CAR)]
+        """
+        patterns: List[Tuple[Dict[int, Label], List[Tuple[Label, Label, bool]]]] = [
+            (
+                {},
+                [
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                    (Label(AutowareLabel.BICYCLE, "bicycle"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                ],
+            ),
+            (
+                {2: Label(AutowareLabel.UNKNOWN, "unknown")},
+                [
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                    (Label(AutowareLabel.BICYCLE, "bicycle"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
+                    (Label(AutowareLabel.UNKNOWN, "unknown"), Label(AutowareLabel.CAR, "car"), True),
+                ],
+            ),
+            (  # check unmatching labels in the same group (CAR vs PEDESTRIAN)
+                {2: Label(AutowareLabel.PEDESTRIAN, "pedestrian")},
+                [
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                    (Label(AutowareLabel.BICYCLE, "bicycle"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
+                    (Label(AutowareLabel.PEDESTRIAN, "pedestrian"), Label(AutowareLabel.CAR, "car"), False),
+                ],
+            ),
+            (  # check matching labels in different groups (PEDESTRIAN vs BICYCLE)
+                {1: Label(AutowareLabel.PEDESTRIAN, "pedestrian")},
+                [
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                    (Label(AutowareLabel.PEDESTRIAN, "pedestrian"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), False),
+                ],
+            ),
+            (  # check matching labels in different groups (TRUCK vs CAR)
+                {2: Label(AutowareLabel.TRUCK, "truck")},
+                [
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
+                    (Label(AutowareLabel.BICYCLE, "bicycle"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
+                    (Label(AutowareLabel.TRUCK, "truck"), Label(AutowareLabel.CAR, "car"), True),
+                ],
+            ),
+        ]
+        for n, (label_remap, expect_list) in enumerate(patterns):
+            with self.subTest(f"Test matching objects: {n + 1}"):
+                estimated_objects = deepcopy(self.dummy_estimated_objects)
+                ground_truth_objects = deepcopy(self.dummy_estimated_objects)
+                for idx, label in label_remap.items():
+                    estimated_objects[idx].semantic_label = label
+
+                object_results: List[DynamicObjectWithPerceptionResult] = get_object_results(
+                    evaluation_task=self.evaluation_task,
+                    estimated_objects=estimated_objects,
+                    ground_truth_objects=ground_truth_objects,
+                    matching_label_policy=MatchingLabelPolicy.ALLOW_SAME_GROUP,
+                )
+
+                for result, expect in zip(object_results, expect_list):
+                    est_label, gt_label, is_label_correct = expect
+                    assert est_label == result.estimated_object.semantic_label
+                    assert gt_label == result.ground_truth_object.semantic_label
+                    assert is_label_correct == result.is_label_correct

--- a/perception_eval/test/evaluation/result/test_object_result.py
+++ b/perception_eval/test/evaluation/result/test_object_result.py
@@ -289,6 +289,10 @@ class TestObjectResult(unittest.TestCase):
                 -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (UNKNOWN, CAR)]
             3. Est: (CAR, BICYCLE, PEDESTRIAN), GT: (CAR, BICYCLE, CAR)
                 -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (PEDESTRIAN, CAR)]
+            4. Est: (CAR, PEDESTRIAN, CAR), GT: (CAR, BICYCLE, CAR)
+                -> TP: [(CAR, CAR), (PEDESTRIAN, BICYCLE), (CAR, CAR)]
+            5. Est: (CAR, BICYCLE, TRUCK), GT: (CAR, BICYCLE, CAR)
+                -> TP: [(CAR, CAR), (BICYCLE, BICYCLE), (TRUCK, CAR)]
         """
         patterns: List[Tuple[Dict[int, Label], List[Tuple[Label, Label, bool]]]] = [
             (
@@ -320,7 +324,7 @@ class TestObjectResult(unittest.TestCase):
                 [
                     (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
                     (Label(AutowareLabel.PEDESTRIAN, "pedestrian"), Label(AutowareLabel.BICYCLE, "bicycle"), True),
-                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), False),
+                    (Label(AutowareLabel.CAR, "car"), Label(AutowareLabel.CAR, "car"), True),
                 ],
             ),
             (  # check matching labels in different groups (TRUCK vs CAR)


### PR DESCRIPTION
## Category

<!-- Please check an item that is most relative category to your changes. -->
<!-- Please delete options that are not relevant. -->

- [x] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

This PR adds new matching method `allow_same_group` to match only same group, which are VEHICLE (car, truck, bus) and VRU(bicycle, motorbike, pedestrian)

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

I will test this PR on the data which match condition like mislabel car and truck.


- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
