### PR TITLE
feat: add traffic cone and barrier as hazard or unknown label

### DIFF
--- a/perception_eval/perception_eval/common/label.py
+++ b/perception_eval/perception_eval/common/label.py
@@ -435,6 +435,9 @@ def _get_autoware_pairs(merge_similar_labels: bool) -> List[Tuple[AutowareLabel,
             (AutowareLabel.UNKNOWN, "movable_object.trafficcone"),
             (AutowareLabel.UNKNOWN, "movable_object.traffic_cone"),
             (AutowareLabel.UNKNOWN, "static_object.bollard"),
+            (AutowareLabel.UNKNOWN, "traffic_cone"),
+            (AutowareLabel.UNKNOWN, "trafficcone"),
+            (AutowareLabel.UNKNOWN, "barrier"),
             (AutowareLabel.UNKNOWN, "hazard"),
         ]
     else:
@@ -461,6 +464,9 @@ def _get_autoware_pairs(merge_similar_labels: bool) -> List[Tuple[AutowareLabel,
             (AutowareLabel.HAZARD, "movable_object.trafficcone"),
             (AutowareLabel.HAZARD, "movable_object.traffic_cone"),
             (AutowareLabel.HAZARD, "static_object.bollard"),
+            (AutowareLabel.HAZARD, "traffic_cone"),
+            (AutowareLabel.HAZARD, "trafficcone"),
+            (AutowareLabel.HAZARD, "barrier"),
             (AutowareLabel.HAZARD, "hazard"),
         ]
     return pair_list


### PR DESCRIPTION
## Category

This PR adds the new label traffic cone and barrier as hazard or unknown.


- [ ] Perception
  - [ ] Detection
  - [ ] Tracking
  - [ ] Prediction
  - [ ] Classification
- [ ] Sensing
- [ ] Other

## What

<!-- Please describe what you changed. -->

## Type of change

<!-- Please check an item that is most relative type of change to yours. -->
<!-- Please delete options that are not relevant. -->

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Change code style
- [ ] Update test
- [ ] Update document
- [ ] Chore

## Test performed

<!-- Describe how you have tested this PR. -->

- [ ] test.sensing_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

- [ ] test.perception_lsim

<details>
<pre>
<code>
<!-- Please paste test result here. -->
</code>
</pre>
</details>

## Reference

<!-- Please write external reference if any. -->

## Notes for reviewer

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
