### PR TITLE
fix(object): use signed yaw in get_heading_bev instead of Quaternion.radians

### DIFF
--- a/perception_eval/perception_eval/common/object.py
+++ b/perception_eval/perception_eval/common/object.py
@@ -262,7 +262,10 @@ class DynamicObject:
             float: The heading (radian)
         """
         if self.frame_id == FrameID.BASE_LINK:
-            rots: float = self.state.orientation.radians
+            # NOTE: Quaternion.radians is the absolute rotation angle and drops the yaw
+            # sign, which collapses mirrored headings (e.g. +theta vs -theta) to zero
+            # error. Use the signed yaw instead.
+            rots: float = self.state.orientation.yaw_pitch_roll[0]
         else:
             if transforms is None:
                 raise ValueError("transforms must be specified.")


### PR DESCRIPTION
## What

`DynamicObject.get_heading_bev()` used `self.state.orientation.radians` in the
BASE_LINK branch. pyquaternion's `.radians` is the **absolute rotation angle**,
so the yaw sign is dropped. This PR switches it to the signed yaw
(`yaw_pitch_roll[0]`), matching the map-frame branch of the same function.

## Why (impact)

`TPMetricsAph` derives the APH heading similarity from `get_heading_bev` of the
estimated and GT objects. With the sign dropped, the heading error degenerates
to `| |yaw_pred| − |yaw_gt| |`:

- Mirrored headings (prediction −θ vs GT +θ) are scored as **perfect matches**.
- Flips across the ±π boundary are likewise under-penalized.

As a result **APH, mAPH, and the mAPH-based NDS are systematically inflated**
for every consumer of these metrics. Classes with frequent 180°/mirror
orientation errors are hit hardest (pedestrians worst in our measurement).

The TP orientation-error path (`TPErrorOrientation`) already uses the signed
yaw, which is why AOE has been correct while APH was not — and why the bug went
unnoticed.

## Verification

BEVFusion-L j6gen2 val (3,645 frames, T4MetricV2, center-distance BEV,
0–121 m):

| | before | after |
|---|---|---|
| mAPH | 0.5911 | **0.5760** |
| pedestrian APH@0.5 | 0.6276 | 0.5922 |

- Replaying both formulas over the exact same matched pairs (dumped from the
  evaluation results pickle) reproduces the before/after numbers to 4 decimal
  places, isolating the change to this line.
- The corrected mAPH agrees with an independent APH implementation
  (autoware-ml detection metric suite, signed-yaw) to 0.0004; before the fix
  the two disagreed by 0.0155.
- A synthetic differential test with non-negative yaws only (where `.radians`
  == signed yaw) shows the two implementations were already identical in every
  other respect (AP interpolation, envelope, F1/operating points).